### PR TITLE
[MERGE] DIContainer

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		0873464C2C0AAF7000534FFA /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0873464B2C0AAF7000534FFA /* RxSwift */; };
 		0873464E2C0AB1CA00534FFA /* ViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0873464D2C0AB1CA00534FFA /* ViewControllerViewModel.swift */; };
 		087346522C0ABC4B00534FFA /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346512C0ABC4B00534FFA /* ViewModel.swift */; };
+		087346562C0AEBD900534FFA /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346552C0AEBD900534FFA /* AppDIContainer.swift */; };
+		087346572C0AED3400534FFA /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346552C0AEBD900534FFA /* AppDIContainer.swift */; };
+		0873465A2C0AED6C00534FFA /* AppDIContainerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346592C0AED6C00534FFA /* AppDIContainerTest.swift */; };
+		0873465B2C0AEFCF00534FFA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346102C0AAD2900534FFA /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +59,8 @@
 		087346332C0AAD2B00534FFA /* PopPoolUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		0873464D2C0AB1CA00534FFA /* ViewControllerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerViewModel.swift; sourceTree = "<group>"; };
 		087346512C0ABC4B00534FFA /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		087346552C0AEBD900534FFA /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
+		087346592C0AED6C00534FFA /* AppDIContainerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainerTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -119,6 +125,7 @@
 		087346262C0AAD2B00534FFA /* PopPoolTests */ = {
 			isa = PBXGroup;
 			children = (
+				087346582C0AED5A00534FFA /* Application */,
 				087346272C0AAD2B00534FFA /* PopPoolTests.swift */,
 			);
 			path = PopPoolTests;
@@ -138,6 +145,7 @@
 			children = (
 				087346102C0AAD2900534FFA /* AppDelegate.swift */,
 				087346122C0AAD2900534FFA /* SceneDelegate.swift */,
+				087346542C0AEBBA00534FFA /* DIContainer */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -184,6 +192,22 @@
 				0873464D2C0AB1CA00534FFA /* ViewControllerViewModel.swift */,
 			);
 			path = "CodeConvention Sample";
+			sourceTree = "<group>";
+		};
+		087346542C0AEBBA00534FFA /* DIContainer */ = {
+			isa = PBXGroup;
+			children = (
+				087346552C0AEBD900534FFA /* AppDIContainer.swift */,
+			);
+			path = DIContainer;
+			sourceTree = "<group>";
+		};
+		087346582C0AED5A00534FFA /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				087346592C0AED6C00534FFA /* AppDIContainerTest.swift */,
+			);
+			path = Application;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -328,6 +352,7 @@
 			files = (
 				087346522C0ABC4B00534FFA /* ViewModel.swift in Sources */,
 				087346152C0AAD2900534FFA /* ViewController.swift in Sources */,
+				087346562C0AEBD900534FFA /* AppDIContainer.swift in Sources */,
 				087346112C0AAD2900534FFA /* AppDelegate.swift in Sources */,
 				0873464E2C0AB1CA00534FFA /* ViewControllerViewModel.swift in Sources */,
 				087346132C0AAD2900534FFA /* SceneDelegate.swift in Sources */,
@@ -338,6 +363,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0873465B2C0AEFCF00534FFA /* AppDelegate.swift in Sources */,
+				087346572C0AED3400534FFA /* AppDIContainer.swift in Sources */,
+				0873465A2C0AED6C00534FFA /* AppDIContainerTest.swift in Sources */,
 				087346282C0AAD2B00534FFA /* PopPoolTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PopPool/PopPool/Application/AppDelegate.swift
+++ b/PopPool/PopPool/Application/AppDelegate.swift
@@ -10,10 +10,10 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        
+        //DIContainer register
+        registerDIContainer()
         return true
     }
 

--- a/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
+++ b/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
@@ -1,0 +1,50 @@
+//
+//  AppDIContainer.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/1/24.
+//
+
+import Foundation
+
+protocol DIContainer {
+    /// 특정 타입에 대한 컴포넌트를 등록합니다.
+    /// - Parameters:
+    ///   - type: 컴포넌트를 등록할 타입.
+    ///   - component: 등록할 컴포넌트 인스턴스.
+    func register<T>(type: T.Type, component: AnyObject)
+    
+    /// 특정 타입에 대한 컴포넌트를 반환합니다.
+    /// - Parameter type: 반환할 컴포넌트의 타입.
+    /// - Returns: 반환된 컴포넌트 인스턴스.
+    func resolve<T>(type: T.Type) -> T
+}
+
+final class AppDIContainer: DIContainer {
+    
+    // AppDIContainer의 싱글톤 인스턴스
+    static let shared = AppDIContainer()
+    
+    // 인스턴스 생성을 방지하기 위한 private 초기화 함수
+    private init() {}
+    
+    // 등록된 서비스를 저장할 딕셔너리
+    private var services: [String: AnyObject] = [:]
+    
+    func register<T>(type: T.Type, component: AnyObject) {
+        let key = "\(type)"
+        services[key] = component
+    }
+    
+    func resolve<T>(type: T.Type) -> T {
+        let key = "\(type)"
+        return services[key] as! T
+    }
+}
+
+extension AppDelegate {
+    /// DI 컨테이너 인스턴스를 등록합니다.
+    func registerDIContainer() {
+        let container = AppDIContainer.shared
+    }
+}

--- a/PopPool/PopPoolTests/Application/AppDIContainerTest.swift
+++ b/PopPool/PopPoolTests/Application/AppDIContainerTest.swift
@@ -52,11 +52,13 @@ final class AppDIContainerTest: XCTestCase {
         super.tearDown()
     }
     
+    /// Dog 인스턴스 등록 후 반환 값 확인
     func testAppDIContainer() {
         let dog = AppDIContainer.shared.resolve(type: Animal.self)
         XCTAssertTrue(dog.name == "백구")
     }
     
+    /// Dog 인스턴스 등록 후 Cat 인스턴스로 변경 후 반환 값 확인
     func testChangeAppDIConainer() {
         AppDIContainer.shared.register(type: Animal.self, component: Cat(name: "나비"))
         let cat = AppDIContainer.shared.resolve(type: Animal.self)

--- a/PopPool/PopPoolTests/Application/AppDIContainerTest.swift
+++ b/PopPool/PopPoolTests/Application/AppDIContainerTest.swift
@@ -1,0 +1,65 @@
+//
+//  AppDIContainerTest.swift
+//  PopPoolTests
+//
+//  Created by SeoJunYoung on 6/1/24.
+//
+
+import Foundation
+import XCTest
+
+protocol Animal {
+    var name:String { get set }
+    func cry() -> String
+}
+
+class Dog: Animal {
+    var name: String
+    
+    func cry() -> String {
+        return "멍멍"
+    }
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    deinit {
+        print(self, "deinit")
+    }
+}
+
+class Cat: Animal {
+    var name: String
+    
+    func cry() -> String {
+        return "야옹"
+    }
+    
+    init(name: String) {
+        self.name = name
+    }
+}
+
+final class AppDIContainerTest: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        AppDIContainer.shared.register(type: Animal.self, component: Dog(name: "백구"))
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testAppDIContainer() {
+        let dog = AppDIContainer.shared.resolve(type: Animal.self)
+        XCTAssertTrue(dog.name == "백구")
+    }
+    
+    func testChangeAppDIConainer() {
+        AppDIContainer.shared.register(type: Animal.self, component: Cat(name: "나비"))
+        let cat = AppDIContainer.shared.resolve(type: Animal.self)
+        XCTAssertTrue(cat.name == "나비")
+    }
+}


### PR DESCRIPTION
## Description
- AppDIContainer 구현
- AppDIContainer 테스트 작성
## Changes
- PopPool/Application 디렉토리에 DIContainer 추가
- PopPoolTests 디렉토리에 Application 추가하여 테스트 케이스 구성
## AppDIContainer
- register<T>(type: T.Type, component: AnyObject): 특정 타입에 대한 컴포넌트를 등록합니다.
- resolve<T>(type: T.Type) -> T : 특정 타입에 대한 컴포넌트를 반환합니다.
## Example
```
AppDIContainer.shared.register(type: Animal.self, component: Dog(name: "백구")) // 등록
let dog = AppDIContainer.shared.resolve(type: Animal.self) // 반환
```
## Test
- ✅ func testAppDIContainer() : Dog 인스턴스 등록 후 반환 값 확인
- ✅ func testChangeAppDIConainer(): Dog 인스턴스 등록 후 Cat 인스턴스로 변경 후 반환 값 확인