### PR TITLE
[MERGE]: ✅ Refactor/di container

### DIFF
--- a/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
+++ b/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
@@ -8,37 +8,70 @@
 import Foundation
 
 protocol DIContainer {
+    
     /// 특정 타입에 대한 컴포넌트를 등록합니다.
     /// - Parameters:
     ///   - type: 컴포넌트를 등록할 타입.
     ///   - component: 등록할 컴포넌트 인스턴스.
     func register<T>(type: T.Type, component: AnyObject)
     
+    /// 특정 타입에 대한 컴포넌트를 등록합니다.
+    /// - Parameters:
+    ///   - type: 컴포넌트를 등록할 타입.
+    ///   - identifier: 식별자
+    ///   - component: 등록할 컴포넌트 인스턴스.
+    func register<T>(type: T.Type, identifier: String, component: AnyObject)
+    
     /// 특정 타입에 대한 컴포넌트를 반환합니다.
     /// - Parameter type: 반환할 컴포넌트의 타입.
     /// - Returns: 반환된 컴포넌트 인스턴스.
     func resolve<T>(type: T.Type) -> T
+    
+    /// 특정 타입에 대한 컴포넌트를 반환합니다.
+    /// - Parameter type: 반환할 컴포넌트의 타입.
+    /// - identifier: 식별자
+    /// - Returns: 반환된 컴포넌트 인스턴스.
+    func resolve<T>(type: T.Type, identifier: String) -> T
 }
 
 final class AppDIContainer: DIContainer {
-    
+
     // AppDIContainer의 싱글톤 인스턴스
     static let shared = AppDIContainer()
     
     // 인스턴스 생성을 방지하기 위한 private 초기화 함수
     private init() {}
     
+    // Default 문자열
+    private var defaultString: String = "Default"
+    
     // 등록된 서비스를 저장할 딕셔너리
-    private var services: [String: AnyObject] = [:]
+    private var services: [String: [String : AnyObject] ] = [:]
     
     func register<T>(type: T.Type, component: AnyObject) {
         let key = "\(type)"
-        services[key] = component
+        services[key] = [defaultString : component]
+    }
+    
+    func register<T>(type: T.Type, identifier: String, component: AnyObject) {
+        let key = "\(type)"
+        if services[key] == nil {
+            services[key] = [identifier : component]
+        } else {
+            services[key]![identifier] = component
+        }
     }
     
     func resolve<T>(type: T.Type) -> T {
         let key = "\(type)"
-        return services[key] as! T
+        let subvalue = services[key]!
+        return subvalue[defaultString] as! T
+    }
+
+    func resolve<T>(type: T.Type, identifier: String) -> T {
+        let key = "\(type)"
+        let subvalue = services[key]!
+        return subvalue[identifier] as! T
     }
 }
 

--- a/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
+++ b/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
@@ -84,10 +84,5 @@ extension AppDelegate {
             type: Provider.self,
             component: ProviderImpl()
         )
-        
-        container.register(
-            type: KeyChainRepository.self,
-            component: KeyChainRepositoryImpl()
-        )
     }
 }

--- a/PopPool/PopPoolTests/Application/AppDIContainerTest.swift
+++ b/PopPool/PopPoolTests/Application/AppDIContainerTest.swift
@@ -45,7 +45,6 @@ final class AppDIContainerTest: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        AppDIContainer.shared.register(type: Animal.self, component: Dog(name: "백구"))
     }
     
     override func tearDown() {
@@ -54,6 +53,7 @@ final class AppDIContainerTest: XCTestCase {
     
     /// Dog 인스턴스 등록 후 반환 값 확인
     func testAppDIContainer() {
+        AppDIContainer.shared.register(type: Animal.self, component: Dog(name: "백구"))
         let dog = AppDIContainer.shared.resolve(type: Animal.self)
         XCTAssertTrue(dog.name == "백구")
     }
@@ -63,5 +63,14 @@ final class AppDIContainerTest: XCTestCase {
         AppDIContainer.shared.register(type: Animal.self, component: Cat(name: "나비"))
         let cat = AppDIContainer.shared.resolve(type: Animal.self)
         XCTAssertTrue(cat.name == "나비")
+    }
+    
+    /// 식별자로 강아지, 고양이 등록후 반환 값 확인
+    func testIdentifier() {
+        AppDIContainer.shared.register(type: Animal.self, identifier: "강아지", component: Dog(name: "백구"))
+        AppDIContainer.shared.register(type: Animal.self, identifier: "고양이", component: Cat(name: "나비"))
+        let dog = AppDIContainer.shared.resolve(type: Animal.self, identifier: "강아지")
+        let cat = AppDIContainer.shared.resolve(type: Animal.self, identifier: "고양이")
+        XCTAssertTrue(cat.name == "나비" && dog.name == "백구")
     }
 }


### PR DESCRIPTION
## Description
- DIContainer 에 identifier 기능을 추가하였습니다.
- 기존 메서드 사용시 default라는 문자열으로 identifier가 설정 됩니다.
## Example
```

    /// 식별자로 강아지, 고양이 등록후 반환 값 확인 -> Test ✅
    func testIdentifier() {
        AppDIContainer.shared.register(type: Animal.self, identifier: "강아지", component: Dog(name: "백구"))
        AppDIContainer.shared.register(type: Animal.self, identifier: "고양이", component: Cat(name: "나비"))
        let dog = AppDIContainer.shared.resolve(type: Animal.self, identifier: "강아지")
        let cat = AppDIContainer.shared.resolve(type: Animal.self, identifier: "고양이")
        XCTAssertTrue(cat.name == "나비" && dog.name == "백구")
    }
```
