### PR TITLE
[MERGE] : ✅ FetchUserCredentialUseCase

### DIFF
--- a/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
+++ b/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
@@ -84,5 +84,17 @@ extension AppDelegate {
             type: Provider.self,
             component: ProviderImpl()
         )
+        
+        container.register(
+            type: FetchUserCredentialUseCase.self,
+            identifier: "Apple",
+            component: FetchUserCredentialUseCaseImpl(service: AppleAuthServiceImpl())
+        )
+        
+        container.register(
+            type: FetchUserCredentialUseCase.self,
+            identifier: "Kakao",
+            component: FetchUserCredentialUseCaseImpl(service: KakaoAuthServiceImpl())
+        )
     }
 }

--- a/PopPool/PopPool/Domain/Interfaces/AuthService.swift
+++ b/PopPool/PopPool/Domain/Interfaces/AuthService.swift
@@ -12,5 +12,5 @@ protocol AuthService: Responsable, AnyObject {
     
     /// 사용자 자격 증명을 가져오는 함수
     /// - Returns: Response 형태의 사용자 자격 증명
-    func fetchUserCredential() -> Observable<Response>
+    func fetchUserCredential() -> Observable<Encodable>
 }

--- a/PopPool/PopPool/Domain/Interfaces/FetchUserCredentialUseCase.swift
+++ b/PopPool/PopPool/Domain/Interfaces/FetchUserCredentialUseCase.swift
@@ -11,8 +11,9 @@ import RxSwift
 
 protocol FetchUserCredentialUseCase {
     
+    var service: any AuthService { get set }
+    
     /// 사용자의 자격 증명을 가져오는 메서드입니다.
-    /// - Parameter service: 인증 서비스 객체
     /// - Returns: 인증 서비스에서 반환하는 응답을 포함하는 Observable 객체
-    func execute<T: AuthService>(service: T) -> Observable<T.Response> 
+    func execute() -> Observable<Encodable>
 }

--- a/PopPool/PopPool/Domain/UseCase/FetchUserCredentialUseCaseImpl.swift
+++ b/PopPool/PopPool/Domain/UseCase/FetchUserCredentialUseCaseImpl.swift
@@ -11,7 +11,13 @@ import RxSwift
 
 final class FetchUserCredentialUseCaseImpl: FetchUserCredentialUseCase {
     
-    func execute<T>(service: T) -> Observable<T.Response> where T : AuthService {
+    var service: any AuthService
+    
+    init(service: any AuthService) {
+        self.service = service
+    }
+
+    func execute() -> Observable<Encodable> {
         return service.fetchUserCredential()
     }
 }

--- a/PopPool/PopPool/Infrastructure/Service/AuthService/Services/AppleAuthServiceImpl.swift
+++ b/PopPool/PopPool/Infrastructure/Service/AuthService/Services/AppleAuthServiceImpl.swift
@@ -12,7 +12,7 @@ import AuthenticationServices
 
 final class AppleAuthServiceImpl: NSObject, AuthService  {
     
-    struct Response {
+    struct Response: Encodable {
         var authorizationCode: String
         var idToken: String
     }
@@ -20,9 +20,11 @@ final class AppleAuthServiceImpl: NSObject, AuthService  {
     // 사용자 자격 증명 정보를 방출할 subject
     private var userCredentialObserver = PublishSubject<Response>()
     
-    func fetchUserCredential() -> Observable<Response> {
+    func fetchUserCredential() -> Observable<Encodable> {
         performRequest()
-        return userCredentialObserver
+        return userCredentialObserver.map { response in
+            return Response(authorizationCode: response.authorizationCode, idToken: response.idToken)
+        }
     }
     
     // Apple 인증 요청을 수행하는 함수

--- a/PopPool/PopPool/Infrastructure/Service/AuthService/Services/KakaoAuthServiceImpl.swift
+++ b/PopPool/PopPool/Infrastructure/Service/AuthService/Services/KakaoAuthServiceImpl.swift
@@ -12,14 +12,14 @@ import RxSwift
 
 final class KakaoAuthServiceImpl: AuthService {
     
-    struct Response {
+    struct Response: Encodable {
         var id: String
         var token: String
     }
     
     private let disposeBag = DisposeBag()
     
-    func fetchUserCredential() -> Observable<Response> {
+    func fetchUserCredential() -> Observable<Encodable> {
         
         return fetchToken()
             .flatMap { token in


### PR DESCRIPTION
## Description
- FetchUserCredentialUseCase를 수정하였습니다.
- 추후 PopPoolAPIEndpoint 수정 예정입니다.
- 추후 KakaoLoginRequestDTO 삭제 예정입니다.
## Changes
- 식별자를 통해 UseCase 2가지를 등록하였습니다.
- 기존 Response 타입을 직접 명시하는 코드에서 Encodable을 리턴하는 것으로 EndPoint의 BodyParam에 사용하기 쉽도록 통일하였습니다.
## Example
```
    var kakaoUseCase: FetchUserCredentialUseCase
    var appleUseCase: FetchUserCredentialUseCase
    
    init() {
        self.kakaoUseCase = AppDIContainer.shared.resolve(type: FetchUserCredentialUseCase.self, identifier: "Kakao")
        self.appleUseCase = AppDIContainer.shared.resolve(type: FetchUserCredentialUseCase.self, identifier: "Apple")
    }

    func exampleKakao() {
        kakaoUseCase.execute()
            .subscribe { userCredential in
                print(userCredential)
            } onError: { error in
                print(error)
            }
            .disposed(by: disposeBag)
    }
```
