### PR TITLE
[MERGE]: ✅ Code Naming Convention 일괄 수정

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -37,13 +37,13 @@
 		0873465B2C0AEFCF00534FFA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346102C0AAD2900534FFA /* AppDelegate.swift */; };
 		087A68B12C1ECEBC00CF3631 /* LocalDBUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087A68B02C1ECEBC00CF3631 /* LocalDBUseCase.swift */; };
 		08A28CAA2C27E16F00DF7A90 /* VCSignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CA92C27E16F00DF7A90 /* VCSignUp.swift */; };
-		08A28CAC2C27E5FB00DF7A90 /* CMPTProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CAB2C27E5FB00DF7A90 /* CMPTProgressIndicator.swift */; };
-		08A28CB42C280F9600DF7A90 /* CMPTProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB32C280F9600DF7A90 /* CMPTProgressView.swift */; };
-		08A28CB62C2A97E300DF7A90 /* CMPTContentTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB52C2A97E300DF7A90 /* CMPTContentTitle.swift */; };
+		08A28CAC2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CAB2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift */; };
+		08A28CB42C280F9600DF7A90 /* ProgressViewCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */; };
+		08A28CB62C2A97E300DF7A90 /* ContentTitleCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB52C2A97E300DF7A90 /* ContentTitleCPNT.swift */; };
 		08A28CBA2C2AC44300DF7A90 /* VMSignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB92C2AC44300DF7A90 /* VMSignUp.swift */; };
-		08A28CBE2C2AEAF600DF7A90 /* CMPTCheckBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CBD2C2AEAF600DF7A90 /* CMPTCheckBox.swift */; };
+		08A28CBE2C2AEAF600DF7A90 /* CheckBoxCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CBD2C2AEAF600DF7A90 /* CheckBoxCPNT.swift */; };
 		08A28CC22C2AF2DD00DF7A90 /* SignUpStep1View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */; };
-		08A28CC42C2B00B700DF7A90 /* CMPTTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC32C2B00B700DF7A90 /* CMPTTermsView.swift */; };
+		08A28CC42C2B00B700DF7A90 /* TermsViewCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC32C2B00B700DF7A90 /* TermsViewCPNT.swift */; };
 		08A28CC62C2BE1EA00DF7A90 /* Inputable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC52C2BE1EA00DF7A90 /* Inputable.swift */; };
 		08A28CC82C2BE1F300DF7A90 /* Outputable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC72C2BE1F300DF7A90 /* Outputable.swift */; };
 		08B965602C1441C100BF95AA /* AppleAuthServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9655F2C1441C100BF95AA /* AppleAuthServiceImpl.swift */; };
@@ -51,7 +51,7 @@
 		08B9658C2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9658B2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift */; };
 		08B9658F2C16004D00BF95AA /* PopPoolAPIEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9658E2C16004D00BF95AA /* PopPoolAPIEndPoint.swift */; };
 		08F49DDB2C200528002D5202 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DDA2C200528002D5202 /* AuthService.swift */; };
-		08F49DE82C231C40002D5202 /* SocialType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE72C231C40002D5202 /* SocialType.swift */; };
+		08F49DE82C231C40002D5202 /* SocialTYPE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE72C231C40002D5202 /* SocialTYPE.swift */; };
 		08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE92C231CFC002D5202 /* LoginResponse.swift */; };
 		08F49DEC2C231D13002D5202 /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */; };
 		08F49DF02C2321B8002D5202 /* AuthRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DEF2C2321B8002D5202 /* AuthRepositoryImpl.swift */; };
@@ -59,16 +59,16 @@
 		08F49DF42C232364002D5202 /* AuthUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF32C232364002D5202 /* AuthUseCase.swift */; };
 		08F49DF62C2323C2002D5202 /* AuthUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF52C2323C2002D5202 /* AuthUseCaseImpl.swift */; };
 		08F49DF92C24006F002D5202 /* ToastMSGManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF82C24006F002D5202 /* ToastMSGManager.swift */; };
-		08F49DFD2C2400FC002D5202 /* CMPTButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DFC2C2400FC002D5202 /* CMPTButton.swift */; };
+		08F49DFD2C2400FC002D5202 /* ButtonCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DFC2C2400FC002D5202 /* ButtonCPNT.swift */; };
 		08F49E092C240335002D5202 /* !_!_!_.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49E082C240335002D5202 /* !_!_!_.swift */; };
 		08F49E0B2C240345002D5202 /* _@_@_.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49E0A2C240345002D5202 /* _@_@_.swift */; };
 		08F49E0F2C240A64002D5202 /* LocalFetchUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49E0E2C240A64002D5202 /* LocalFetchUseCaseImpl.swift */; };
 		BD2E90F52C1B17C200BB0313 /* KeyChainRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E90F42C1B17C200BB0313 /* KeyChainRepositoryImpl.swift */; };
+		BD353B452C2BE42C0004659D /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD353B442C2BE42C0004659D /* Secrets.swift */; };
 		BD6368082C0CBEFE00891A1B /* PopPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6368072C0CBEFE00891A1B /* PopPoolTests.swift */; };
 		BD8607972C23418800726692 /* LocalDeleteUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8607962C23418800726692 /* LocalDeleteUseCaseImpl.swift */; };
-		BD86079B2C23429D00726692 /* DatabaseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86079A2C23429D00726692 /* DatabaseType.swift */; };
-		BD9901CB2C28742B0024F30D /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9901CA2C28742B0024F30D /* Secrets.swift */; };
-		BD9901CD2C2877BF0024F30D /* CMPTToastMSG.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9901CC2C2877BF0024F30D /* CMPTToastMSG.swift */; };
+		BD86079B2C23429D00726692 /* DatabaseTYPE.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86079A2C23429D00726692 /* DatabaseTYPE.swift */; };
+		BD9901CD2C2877BF0024F30D /* ToastMSGCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9901CC2C2877BF0024F30D /* ToastMSGCPNT.swift */; };
 		BDB682552C1C316000560E7B /* LocalDBRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB682542C1C316000560E7B /* LocalDBRepository.swift */; };
 		BDC622B12C225817009411AE /* DatabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B02C225817009411AE /* DatabaseError.swift */; };
 		BDC622B52C2294D4009411AE /* LocalSaveUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B42C2294D4009411AE /* LocalSaveUseCaseImpl.swift */; };
@@ -80,7 +80,7 @@
 		BDF3B2C12C0C318E00B079C5 /* Responsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF3B2C02C0C318E00B079C5 /* Responsable.swift */; };
 		BDF4F2962C240B95002F4F03 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4F2952C240B95002F4F03 /* UIColor+.swift */; };
 		BDF4F2982C240BA6002F4F03 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4F2972C240BA6002F4F03 /* Constants.swift */; };
-		BDF4F29C2C2422DF002F4F03 /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4F29B2C2422DF002F4F03 /* UIFont.swift */; };
+		BDF4F29C2C2422DF002F4F03 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4F29B2C2422DF002F4F03 /* UIFont+.swift */; };
 		BDF4F2A22C243035002F4F03 /* Poppins-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BDF4F29E2C243035002F4F03 /* Poppins-Regular.ttf */; };
 		BDF4F2A32C243035002F4F03 /* Poppins-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BDF4F29F2C243035002F4F03 /* Poppins-Bold.ttf */; };
 		BDF4F2A42C243035002F4F03 /* Poppins-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BDF4F2A02C243035002F4F03 /* Poppins-Light.ttf */; };
@@ -128,13 +128,13 @@
 		087346592C0AED6C00534FFA /* AppDIContainerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainerTest.swift; sourceTree = "<group>"; };
 		087A68B02C1ECEBC00CF3631 /* LocalDBUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBUseCase.swift; sourceTree = "<group>"; };
 		08A28CA92C27E16F00DF7A90 /* VCSignUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCSignUp.swift; sourceTree = "<group>"; };
-		08A28CAB2C27E5FB00DF7A90 /* CMPTProgressIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTProgressIndicator.swift; sourceTree = "<group>"; };
-		08A28CB32C280F9600DF7A90 /* CMPTProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTProgressView.swift; sourceTree = "<group>"; };
-		08A28CB52C2A97E300DF7A90 /* CMPTContentTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTContentTitle.swift; sourceTree = "<group>"; };
+		08A28CAB2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorCPNT.swift; sourceTree = "<group>"; };
+		08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewCPNT.swift; sourceTree = "<group>"; };
+		08A28CB52C2A97E300DF7A90 /* ContentTitleCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTitleCPNT.swift; sourceTree = "<group>"; };
 		08A28CB92C2AC44300DF7A90 /* VMSignUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSignUp.swift; sourceTree = "<group>"; };
-		08A28CBD2C2AEAF600DF7A90 /* CMPTCheckBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTCheckBox.swift; sourceTree = "<group>"; };
+		08A28CBD2C2AEAF600DF7A90 /* CheckBoxCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxCPNT.swift; sourceTree = "<group>"; };
 		08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStep1View.swift; sourceTree = "<group>"; };
-		08A28CC32C2B00B700DF7A90 /* CMPTTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTTermsView.swift; sourceTree = "<group>"; };
+		08A28CC32C2B00B700DF7A90 /* TermsViewCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewCPNT.swift; sourceTree = "<group>"; };
 		08A28CC52C2BE1EA00DF7A90 /* Inputable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inputable.swift; sourceTree = "<group>"; };
 		08A28CC72C2BE1F300DF7A90 /* Outputable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Outputable.swift; sourceTree = "<group>"; };
 		08B9655E2C14410700BF95AA /* PopPool.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PopPool.entitlements; sourceTree = "<group>"; };
@@ -143,7 +143,7 @@
 		08B9658B2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserCredentialUseCase.swift; sourceTree = "<group>"; };
 		08B9658E2C16004D00BF95AA /* PopPoolAPIEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolAPIEndPoint.swift; sourceTree = "<group>"; };
 		08F49DDA2C200528002D5202 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
-		08F49DE72C231C40002D5202 /* SocialType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialType.swift; sourceTree = "<group>"; };
+		08F49DE72C231C40002D5202 /* SocialTYPE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialTYPE.swift; sourceTree = "<group>"; };
 		08F49DE92C231CFC002D5202 /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
 		08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDTO.swift; sourceTree = "<group>"; };
 		08F49DEF2C2321B8002D5202 /* AuthRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -151,16 +151,16 @@
 		08F49DF32C232364002D5202 /* AuthUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUseCase.swift; sourceTree = "<group>"; };
 		08F49DF52C2323C2002D5202 /* AuthUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUseCaseImpl.swift; sourceTree = "<group>"; };
 		08F49DF82C24006F002D5202 /* ToastMSGManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMSGManager.swift; sourceTree = "<group>"; };
-		08F49DFC2C2400FC002D5202 /* CMPTButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTButton.swift; sourceTree = "<group>"; };
+		08F49DFC2C2400FC002D5202 /* ButtonCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonCPNT.swift; sourceTree = "<group>"; };
 		08F49E082C240335002D5202 /* !_!_!_.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "!_!_!_.swift"; sourceTree = "<group>"; };
 		08F49E0A2C240345002D5202 /* _@_@_.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_@_@_.swift"; sourceTree = "<group>"; };
 		08F49E0E2C240A64002D5202 /* LocalFetchUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFetchUseCaseImpl.swift; sourceTree = "<group>"; };
 		BD2E90F42C1B17C200BB0313 /* KeyChainRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainRepositoryImpl.swift; sourceTree = "<group>"; };
+		BD353B442C2BE42C0004659D /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		BD6368072C0CBEFE00891A1B /* PopPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolTests.swift; sourceTree = "<group>"; };
 		BD8607962C23418800726692 /* LocalDeleteUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDeleteUseCaseImpl.swift; sourceTree = "<group>"; };
-		BD86079A2C23429D00726692 /* DatabaseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseType.swift; sourceTree = "<group>"; };
-		BD9901CA2C28742B0024F30D /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
-		BD9901CC2C2877BF0024F30D /* CMPTToastMSG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTToastMSG.swift; sourceTree = "<group>"; };
+		BD86079A2C23429D00726692 /* DatabaseTYPE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTYPE.swift; sourceTree = "<group>"; };
+		BD9901CC2C2877BF0024F30D /* ToastMSGCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMSGCPNT.swift; sourceTree = "<group>"; };
 		BDB682542C1C316000560E7B /* LocalDBRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBRepository.swift; sourceTree = "<group>"; };
 		BDC622B02C225817009411AE /* DatabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseError.swift; sourceTree = "<group>"; };
 		BDC622B42C2294D4009411AE /* LocalSaveUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSaveUseCaseImpl.swift; sourceTree = "<group>"; };
@@ -172,7 +172,7 @@
 		BDF3B2C02C0C318E00B079C5 /* Responsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Responsable.swift; sourceTree = "<group>"; };
 		BDF4F2952C240B95002F4F03 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		BDF4F2972C240BA6002F4F03 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		BDF4F29B2C2422DF002F4F03 /* UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
+		BDF4F29B2C2422DF002F4F03 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		BDF4F29E2C243035002F4F03 /* Poppins-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Poppins-Regular.ttf"; sourceTree = "<group>"; };
 		BDF4F29F2C243035002F4F03 /* Poppins-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Poppins-Bold.ttf"; sourceTree = "<group>"; };
 		BDF4F2A02C243035002F4F03 /* Poppins-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Poppins-Light.ttf"; sourceTree = "<group>"; };
@@ -344,7 +344,7 @@
 				BDF4F29D2C242FE8002F4F03 /* Font */,
 				087346192C0AAD2B00534FFA /* Assets.xcassets */,
 				0873461B2C0AAD2B00534FFA /* LaunchScreen.storyboard */,
-				BD9901CA2C28742B0024F30D /* Secrets.swift */,
+				BD353B442C2BE42C0004659D /* Secrets.swift */,
 				0873461E2C0AAD2B00534FFA /* Info.plist */,
 			);
 			path = Resource;
@@ -419,8 +419,8 @@
 		08A28CC02C2AF2C100DF7A90 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				08A28CBD2C2AEAF600DF7A90 /* CMPTCheckBox.swift */,
-				08A28CC32C2B00B700DF7A90 /* CMPTTermsView.swift */,
+				08A28CBD2C2AEAF600DF7A90 /* CheckBoxCPNT.swift */,
+				08A28CC32C2B00B700DF7A90 /* TermsViewCPNT.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -512,8 +512,8 @@
 		08F49DE62C231C30002D5202 /* Enums */ = {
 			isa = PBXGroup;
 			children = (
-				08F49DE72C231C40002D5202 /* SocialType.swift */,
-				BD86079A2C23429D00726692 /* DatabaseType.swift */,
+				08F49DE72C231C40002D5202 /* SocialTYPE.swift */,
+				BD86079A2C23429D00726692 /* DatabaseTYPE.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -521,11 +521,11 @@
 		08F49DF72C23FC5F002D5202 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				08F49DFC2C2400FC002D5202 /* CMPTButton.swift */,
-				08A28CAB2C27E5FB00DF7A90 /* CMPTProgressIndicator.swift */,
-				08A28CB32C280F9600DF7A90 /* CMPTProgressView.swift */,
-				BD9901CC2C2877BF0024F30D /* CMPTToastMSG.swift */,
-				08A28CB52C2A97E300DF7A90 /* CMPTContentTitle.swift */,
+				08F49DFC2C2400FC002D5202 /* ButtonCPNT.swift */,
+				08A28CAB2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift */,
+				08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */,
+				BD9901CC2C2877BF0024F30D /* ToastMSGCPNT.swift */,
+				08A28CB52C2A97E300DF7A90 /* ContentTitleCPNT.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -639,7 +639,7 @@
 			isa = PBXGroup;
 			children = (
 				BDF4F2952C240B95002F4F03 /* UIColor+.swift */,
-				BDF4F29B2C2422DF002F4F03 /* UIFont.swift */,
+				BDF4F29B2C2422DF002F4F03 /* UIFont+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -826,19 +826,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				08A28CBE2C2AEAF600DF7A90 /* CMPTCheckBox.swift in Sources */,
-				08A28CAC2C27E5FB00DF7A90 /* CMPTProgressIndicator.swift in Sources */,
-				08A28CC42C2B00B700DF7A90 /* CMPTTermsView.swift in Sources */,
+				08A28CBE2C2AEAF600DF7A90 /* CheckBoxCPNT.swift in Sources */,
+				08A28CAC2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift in Sources */,
+				08A28CC42C2B00B700DF7A90 /* TermsViewCPNT.swift in Sources */,
 				087346522C0ABC4B00534FFA /* ViewModelable.swift in Sources */,
-				08F49DFD2C2400FC002D5202 /* CMPTButton.swift in Sources */,
+				08F49DFD2C2400FC002D5202 /* ButtonCPNT.swift in Sources */,
 				08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */,
-				BD86079B2C23429D00726692 /* DatabaseType.swift in Sources */,
+				BD86079B2C23429D00726692 /* DatabaseTYPE.swift in Sources */,
 				085105822C102F8000ED7DBB /* KakaoAuthServiceImpl.swift in Sources */,
-				BD9901CB2C28742B0024F30D /* Secrets.swift in Sources */,
 				087346152C0AAD2900534FFA /* ViewController.swift in Sources */,
 				08A28CC62C2BE1EA00DF7A90 /* Inputable.swift in Sources */,
 				08B9658C2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift in Sources */,
-				BDF4F29C2C2422DF002F4F03 /* UIFont.swift in Sources */,
+				BDF4F29C2C2422DF002F4F03 /* UIFont+.swift in Sources */,
 				BDF3B2C12C0C318E00B079C5 /* Responsable.swift in Sources */,
 				085105A02C1038EB00ED7DBB /* AuthError.swift in Sources */,
 				BDF3B2AA2C0BE23D00B079C5 /* Requestable.swift in Sources */,
@@ -848,7 +847,7 @@
 				08F49E0F2C240A64002D5202 /* LocalFetchUseCaseImpl.swift in Sources */,
 				BD2E90F52C1B17C200BB0313 /* KeyChainRepositoryImpl.swift in Sources */,
 				BDC622B12C225817009411AE /* DatabaseError.swift in Sources */,
-				08A28CB62C2A97E300DF7A90 /* CMPTContentTitle.swift in Sources */,
+				08A28CB62C2A97E300DF7A90 /* ContentTitleCPNT.swift in Sources */,
 				087346562C0AEBD900534FFA /* AppDIContainer.swift in Sources */,
 				08F49DF22C23230C002D5202 /* AuthRepository.swift in Sources */,
 				BDF4F2982C240BA6002F4F03 /* Constants.swift in Sources */,
@@ -856,14 +855,15 @@
 				0873464E2C0AB1CA00534FFA /* ViewControllerViewModel.swift in Sources */,
 				BDC622B72C229517009411AE /* UserdefaultRepositoryImpl.swift in Sources */,
 				087346132C0AAD2900534FFA /* SceneDelegate.swift in Sources */,
-				08F49DE82C231C40002D5202 /* SocialType.swift in Sources */,
+				08F49DE82C231C40002D5202 /* SocialTYPE.swift in Sources */,
 				087A68B12C1ECEBC00CF3631 /* LocalDBUseCase.swift in Sources */,
+				BD353B452C2BE42C0004659D /* Secrets.swift in Sources */,
 				08B9658F2C16004D00BF95AA /* PopPoolAPIEndPoint.swift in Sources */,
-				BD9901CD2C2877BF0024F30D /* CMPTToastMSG.swift in Sources */,
+				BD9901CD2C2877BF0024F30D /* ToastMSGCPNT.swift in Sources */,
 				BDD3351A2C0B3AF1002C2295 /* NetworkError.swift in Sources */,
 				08F49E0B2C240345002D5202 /* _@_@_.swift in Sources */,
 				08B965602C1441C100BF95AA /* AppleAuthServiceImpl.swift in Sources */,
-				08A28CB42C280F9600DF7A90 /* CMPTProgressView.swift in Sources */,
+				08A28CB42C280F9600DF7A90 /* ProgressViewCPNT.swift in Sources */,
 				08F49E092C240335002D5202 /* !_!_!_.swift in Sources */,
 				BDF3B2AE2C0BE69700B079C5 /* Provider.swift in Sources */,
 				08A28CBA2C2AC44300DF7A90 /* VMSignUp.swift in Sources */,

--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		0873464A2C0AAF7000534FFA /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 087346492C0AAF7000534FFA /* RxRelay */; };
 		0873464C2C0AAF7000534FFA /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0873464B2C0AAF7000534FFA /* RxSwift */; };
 		0873464E2C0AB1CA00534FFA /* ViewControllerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0873464D2C0AB1CA00534FFA /* ViewControllerViewModel.swift */; };
-		087346522C0ABC4B00534FFA /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346512C0ABC4B00534FFA /* ViewModel.swift */; };
+		087346522C0ABC4B00534FFA /* ViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346512C0ABC4B00534FFA /* ViewModelable.swift */; };
 		087346562C0AEBD900534FFA /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346552C0AEBD900534FFA /* AppDIContainer.swift */; };
 		087346572C0AED3400534FFA /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346552C0AEBD900534FFA /* AppDIContainer.swift */; };
 		0873465A2C0AED6C00534FFA /* AppDIContainerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346592C0AED6C00534FFA /* AppDIContainerTest.swift */; };
@@ -44,6 +44,8 @@
 		08A28CBE2C2AEAF600DF7A90 /* CMPTCheckBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CBD2C2AEAF600DF7A90 /* CMPTCheckBox.swift */; };
 		08A28CC22C2AF2DD00DF7A90 /* SignUpStep1View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */; };
 		08A28CC42C2B00B700DF7A90 /* CMPTTermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC32C2B00B700DF7A90 /* CMPTTermsView.swift */; };
+		08A28CC62C2BE1EA00DF7A90 /* Inputable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC52C2BE1EA00DF7A90 /* Inputable.swift */; };
+		08A28CC82C2BE1F300DF7A90 /* Outputable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC72C2BE1F300DF7A90 /* Outputable.swift */; };
 		08B965602C1441C100BF95AA /* AppleAuthServiceImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9655F2C1441C100BF95AA /* AppleAuthServiceImpl.swift */; };
 		08B9658A2C15FEBF00BF95AA /* FetchUserCredentialUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B965892C15FEBF00BF95AA /* FetchUserCredentialUseCaseImpl.swift */; };
 		08B9658C2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9658B2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift */; };
@@ -56,7 +58,7 @@
 		08F49DF22C23230C002D5202 /* AuthRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF12C23230C002D5202 /* AuthRepository.swift */; };
 		08F49DF42C232364002D5202 /* AuthUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF32C232364002D5202 /* AuthUseCase.swift */; };
 		08F49DF62C2323C2002D5202 /* AuthUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF52C2323C2002D5202 /* AuthUseCaseImpl.swift */; };
-		08F49DF92C24006F002D5202 /* CMPTToastMSGManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF82C24006F002D5202 /* CMPTToastMSGManager.swift */; };
+		08F49DF92C24006F002D5202 /* ToastMSGManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DF82C24006F002D5202 /* ToastMSGManager.swift */; };
 		08F49DFD2C2400FC002D5202 /* CMPTButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DFC2C2400FC002D5202 /* CMPTButton.swift */; };
 		08F49E092C240335002D5202 /* !_!_!_.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49E082C240335002D5202 /* !_!_!_.swift */; };
 		08F49E0B2C240345002D5202 /* _@_@_.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49E0A2C240345002D5202 /* _@_@_.swift */; };
@@ -121,7 +123,7 @@
 		087346312C0AAD2B00534FFA /* PopPoolUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolUITests.swift; sourceTree = "<group>"; };
 		087346332C0AAD2B00534FFA /* PopPoolUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		0873464D2C0AB1CA00534FFA /* ViewControllerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerViewModel.swift; sourceTree = "<group>"; };
-		087346512C0ABC4B00534FFA /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		087346512C0ABC4B00534FFA /* ViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelable.swift; sourceTree = "<group>"; };
 		087346552C0AEBD900534FFA /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
 		087346592C0AED6C00534FFA /* AppDIContainerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainerTest.swift; sourceTree = "<group>"; };
 		087A68B02C1ECEBC00CF3631 /* LocalDBUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBUseCase.swift; sourceTree = "<group>"; };
@@ -133,6 +135,8 @@
 		08A28CBD2C2AEAF600DF7A90 /* CMPTCheckBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTCheckBox.swift; sourceTree = "<group>"; };
 		08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStep1View.swift; sourceTree = "<group>"; };
 		08A28CC32C2B00B700DF7A90 /* CMPTTermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTTermsView.swift; sourceTree = "<group>"; };
+		08A28CC52C2BE1EA00DF7A90 /* Inputable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inputable.swift; sourceTree = "<group>"; };
+		08A28CC72C2BE1F300DF7A90 /* Outputable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Outputable.swift; sourceTree = "<group>"; };
 		08B9655E2C14410700BF95AA /* PopPool.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PopPool.entitlements; sourceTree = "<group>"; };
 		08B9655F2C1441C100BF95AA /* AppleAuthServiceImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthServiceImpl.swift; sourceTree = "<group>"; };
 		08B965892C15FEBF00BF95AA /* FetchUserCredentialUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserCredentialUseCaseImpl.swift; sourceTree = "<group>"; };
@@ -146,7 +150,7 @@
 		08F49DF12C23230C002D5202 /* AuthRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRepository.swift; sourceTree = "<group>"; };
 		08F49DF32C232364002D5202 /* AuthUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUseCase.swift; sourceTree = "<group>"; };
 		08F49DF52C2323C2002D5202 /* AuthUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthUseCaseImpl.swift; sourceTree = "<group>"; };
-		08F49DF82C24006F002D5202 /* CMPTToastMSGManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTToastMSGManager.swift; sourceTree = "<group>"; };
+		08F49DF82C24006F002D5202 /* ToastMSGManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMSGManager.swift; sourceTree = "<group>"; };
 		08F49DFC2C2400FC002D5202 /* CMPTButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPTButton.swift; sourceTree = "<group>"; };
 		08F49E082C240335002D5202 /* !_!_!_.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "!_!_!_.swift"; sourceTree = "<group>"; };
 		08F49E0A2C240345002D5202 /* _@_@_.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_@_@_.swift"; sourceTree = "<group>"; };
@@ -360,6 +364,7 @@
 		0873464F2C0ABC2300534FFA /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				BD0B8F512C26D59600FFBC24 /* Manager */,
 				BDF4F2942C240B86002F4F03 /* Utility */,
 				BDF4F2932C240B70002F4F03 /* Extension */,
 				08F49DE62C231C30002D5202 /* Enums */,
@@ -371,7 +376,9 @@
 		087346502C0ABC2A00534FFA /* Interfaces */ = {
 			isa = PBXGroup;
 			children = (
-				087346512C0ABC4B00534FFA /* ViewModel.swift */,
+				087346512C0ABC4B00534FFA /* ViewModelable.swift */,
+				08A28CC52C2BE1EA00DF7A90 /* Inputable.swift */,
+				08A28CC72C2BE1F300DF7A90 /* Outputable.swift */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -514,7 +521,6 @@
 		08F49DF72C23FC5F002D5202 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				BD0B8F512C26D59600FFBC24 /* Manager */,
 				08F49DFC2C2400FC002D5202 /* CMPTButton.swift */,
 				08A28CAB2C27E5FB00DF7A90 /* CMPTProgressIndicator.swift */,
 				08A28CB32C280F9600DF7A90 /* CMPTProgressView.swift */,
@@ -572,7 +578,7 @@
 		BD0B8F512C26D59600FFBC24 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
-				08F49DF82C24006F002D5202 /* CMPTToastMSGManager.swift */,
+				08F49DF82C24006F002D5202 /* ToastMSGManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -823,20 +829,22 @@
 				08A28CBE2C2AEAF600DF7A90 /* CMPTCheckBox.swift in Sources */,
 				08A28CAC2C27E5FB00DF7A90 /* CMPTProgressIndicator.swift in Sources */,
 				08A28CC42C2B00B700DF7A90 /* CMPTTermsView.swift in Sources */,
-				087346522C0ABC4B00534FFA /* ViewModel.swift in Sources */,
+				087346522C0ABC4B00534FFA /* ViewModelable.swift in Sources */,
 				08F49DFD2C2400FC002D5202 /* CMPTButton.swift in Sources */,
 				08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */,
 				BD86079B2C23429D00726692 /* DatabaseType.swift in Sources */,
 				085105822C102F8000ED7DBB /* KakaoAuthServiceImpl.swift in Sources */,
 				BD9901CB2C28742B0024F30D /* Secrets.swift in Sources */,
 				087346152C0AAD2900534FFA /* ViewController.swift in Sources */,
+				08A28CC62C2BE1EA00DF7A90 /* Inputable.swift in Sources */,
 				08B9658C2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift in Sources */,
 				BDF4F29C2C2422DF002F4F03 /* UIFont.swift in Sources */,
 				BDF3B2C12C0C318E00B079C5 /* Responsable.swift in Sources */,
 				085105A02C1038EB00ED7DBB /* AuthError.swift in Sources */,
 				BDF3B2AA2C0BE23D00B079C5 /* Requestable.swift in Sources */,
+				08A28CC82C2BE1F300DF7A90 /* Outputable.swift in Sources */,
 				08F49DDB2C200528002D5202 /* AuthService.swift in Sources */,
-				08F49DF92C24006F002D5202 /* CMPTToastMSGManager.swift in Sources */,
+				08F49DF92C24006F002D5202 /* ToastMSGManager.swift in Sources */,
 				08F49E0F2C240A64002D5202 /* LocalFetchUseCaseImpl.swift in Sources */,
 				BD2E90F52C1B17C200BB0313 /* KeyChainRepositoryImpl.swift in Sources */,
 				BDC622B12C225817009411AE /* DatabaseError.swift in Sources */,
@@ -1055,6 +1063,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1065,6 +1074,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1086,6 +1096,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1096,6 +1107,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk.git",
       "state" : {
-        "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940",
-        "version" : "2.22.3"
+        "revision" : "9f9b830dfd7ee66607c6fddcfeb1a6bc07e48714",
+        "version" : "2.22.2"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
       "state" : {
-        "revision" : "37ac7e289fea5f62b3b1f62d06290a18a202a5b0",
-        "version" : "2.22.3"
+        "revision" : "86d53e524acd1a9eb0a2c95d23e700ac9d727480",
+        "version" : "2.22.2"
       }
     },
     {

--- a/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
+++ b/PopPool/PopPool/Application/DIContainer/AppDIContainer.swift
@@ -92,13 +92,13 @@ extension AppDelegate {
         
         container.register(
             type: FetchUserCredentialUseCase.self,
-            identifier: SocialType.apple.rawValue,
+            identifier: SocialTYPE.apple.rawValue,
             component: FetchUserCredentialUseCaseImpl(service: AppleAuthServiceImpl())
         )
         
         container.register(
             type: FetchUserCredentialUseCase.self,
-            identifier: SocialType.kakao.rawValue,
+            identifier: SocialTYPE.kakao.rawValue,
             component: FetchUserCredentialUseCaseImpl(service: KakaoAuthServiceImpl())
         )
         

--- a/PopPool/PopPool/Infrastructure/Service/AuthService/Services/AppleAuthServiceImpl.swift
+++ b/PopPool/PopPool/Infrastructure/Service/AuthService/Services/AppleAuthServiceImpl.swift
@@ -55,15 +55,6 @@ extension AppleAuthServiceImpl: ASAuthorizationControllerPresentationContextProv
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
-
-            print("authorizedScopes:", appleIDCredential.authorizedScopes)
-            print("email:", appleIDCredential.email)
-            print("fullName:", appleIDCredential.fullName)
-
-            print("realUserStatus:", appleIDCredential.realUserStatus)
-            print("state:", appleIDCredential.state)
-            print("user:", appleIDCredential.user)
-            print("userAgeRange:", appleIDCredential.userAgeRange)
             
             guard let authorizationCode = appleIDCredential.authorizationCode,
                   let idToken = appleIDCredential.identityToken 
@@ -80,8 +71,6 @@ extension AppleAuthServiceImpl: ASAuthorizationControllerPresentationContextProv
                 userCredentialObserver.onError(AuthError.unknownError)
                 return
             }
-                        print("identityToken:", idToken)
-                        print("authorizationCode:", authorizationCode)
             // 성공적으로 사용자 자격 증명을 방출
             userCredentialObserver.onNext(.init(authorizationCode: authorizationCode, idToken: idToken))
             userCredentialObserver.onCompleted()

--- a/PopPool/PopPool/Presentation/CodeConvention Sample/ViewControllerViewModel.swift
+++ b/PopPool/PopPool/Presentation/CodeConvention Sample/ViewControllerViewModel.swift
@@ -43,7 +43,7 @@ final class ViewControllerViewModel: ViewModelable {
     init() {
         self.fetchUserCredentialUseCase = AppDIContainer.shared.resolve(
             type: FetchUserCredentialUseCase.self,
-            identifier: SocialType.apple.rawValue
+            identifier: SocialTYPE.apple.rawValue
         )
         
         self.authUseCase = AppDIContainer.shared.resolve(
@@ -81,7 +81,7 @@ final class ViewControllerViewModel: ViewModelable {
             .withUnretained(self)
             .subscribe { (owner, userCredential) in
                 owner.authUseCase
-                    .tryLogIn(userCredential: userCredential, socialType: SocialType.apple.rawValue)
+                    .tryLogIn(userCredential: userCredential, socialType: SocialTYPE.apple.rawValue)
                     .subscribe { loginResponse in
                         print(loginResponse)
                     } onError: { error in

--- a/PopPool/PopPool/Presentation/CodeConvention Sample/ViewControllerViewModel.swift
+++ b/PopPool/PopPool/Presentation/CodeConvention Sample/ViewControllerViewModel.swift
@@ -15,7 +15,7 @@ protocol HomeViewControllerDelegate {
     func pushToNextViewController()
 }
 
-final class ViewControllerViewModel: ViewModel {
+final class ViewControllerViewModel: ViewModelable {
     
     struct Input {
         var didTapButton: Signal<Void>

--- a/PopPool/PopPool/Presentation/Common/Enums/DatabaseTYPE.swift
+++ b/PopPool/PopPool/Presentation/Common/Enums/DatabaseTYPE.swift
@@ -1,5 +1,5 @@
 //
-//  LocalDatabase.swift
+//  DatabaseTYPE.swift
 //  PopPool
 //
 //  Created by Porori on 6/20/24.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum DatabaseType: String {
+enum DatabaseTYPE: String {
     case keychain = "Keychain"
     case userdefault = "Userdefault"
 }

--- a/PopPool/PopPool/Presentation/Common/Enums/SocialTYPE.swift
+++ b/PopPool/PopPool/Presentation/Common/Enums/SocialTYPE.swift
@@ -1,5 +1,5 @@
 //
-//  SocialType.swift
+//  SocialTYPE.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/19/24.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum SocialType: String {
+enum SocialTYPE: String {
     case apple = "Apple"
     case kakao = "Kakao"
 }

--- a/PopPool/PopPool/Presentation/Common/Extension/UIFont+.swift
+++ b/PopPool/PopPool/Presentation/Common/Extension/UIFont+.swift
@@ -1,5 +1,5 @@
 //
-//  UIFont.swift
+//  UIFont+.swift
 //  PopPool
 //
 //  Created by Porori on 6/20/24.

--- a/PopPool/PopPool/Presentation/Common/Interfaces/Inputable.swift
+++ b/PopPool/PopPool/Presentation/Common/Interfaces/Inputable.swift
@@ -1,0 +1,12 @@
+//
+//  Inputable.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/26/24.
+//
+
+import Foundation
+
+protocol Inputable {
+    associatedtype Input
+}

--- a/PopPool/PopPool/Presentation/Common/Interfaces/Outputable.swift
+++ b/PopPool/PopPool/Presentation/Common/Interfaces/Outputable.swift
@@ -1,0 +1,12 @@
+//
+//  Outputable.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/26/24.
+//
+
+import Foundation
+
+protocol Outputable {
+    associatedtype Output
+}

--- a/PopPool/PopPool/Presentation/Common/Interfaces/ViewModelable.swift
+++ b/PopPool/PopPool/Presentation/Common/Interfaces/ViewModelable.swift
@@ -7,10 +7,7 @@
 
 import RxSwift
 
-protocol ViewModel {
-    associatedtype Input
-    associatedtype Output
-    
+protocol ViewModelable: Inputable, Outputable {
     func transform(input: Input) -> Output
     var disposeBag: DisposeBag { get set }
 }

--- a/PopPool/PopPool/Presentation/Common/Manager/ToastMSGManager.swift
+++ b/PopPool/PopPool/Presentation/Common/Manager/ToastMSGManager.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTToastMSGManager.swift
+//  ToastMSGManager.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/20/24.
@@ -14,12 +14,12 @@ import Foundation
 import UIKit
 import SnapKit
 
-final class CMPTToastMSGManager {
+final class ToastMSGManager {
     
     // MARK: - Properties
     
     /// 현재 디바이스 최상단 Window를 지정
-    private var window: UIWindow? {
+    static var window: UIWindow? {
         return UIApplication
             .shared
             .connectedScenes
@@ -28,14 +28,13 @@ final class CMPTToastMSGManager {
     }
 }
 
-extension CMPTToastMSGManager {
+extension ToastMSGManager {
     
     // MARK: - Method
     
     /// 토스트 메시지를 생성하는 메서드
     /// - Parameter message: 토스트 메세지에 담길 String 타입
-    func createToast(message: String) {
-        
+   static func createToast(message: String) {
         let toastMSG = CMPTToastMSG(message: message)
         window?.addSubview(toastMSG)
         

--- a/PopPool/PopPool/Presentation/Common/Manager/ToastMSGManager.swift
+++ b/PopPool/PopPool/Presentation/Common/Manager/ToastMSGManager.swift
@@ -35,7 +35,7 @@ extension ToastMSGManager {
     /// 토스트 메시지를 생성하는 메서드
     /// - Parameter message: 토스트 메세지에 담길 String 타입
    static func createToast(message: String) {
-        let toastMSG = CMPTToastMSG(message: message)
+        let toastMSG = ToastMSGCPNT(message: message)
         window?.addSubview(toastMSG)
         
         toastMSG.snp.makeConstraints { make in

--- a/PopPool/PopPool/Presentation/Common/Utility/Constants.swift
+++ b/PopPool/PopPool/Presentation/Common/Utility/Constants.swift
@@ -9,43 +9,26 @@ import Foundation
 
 // MARK: - Space Guide
 
-//struct SpaceGuide {
-//    let _4px = 4
-//    let _8px = 8
-//    let _12px = 12
-//    let _16px = 16
-//    let _20px = 20
-//    let _24px = 24
-//    let _28px = 28
-//    let _32px = 32
-//    let _36px = 36
-//    let _40px = 40
-//    let _48px = 48
-//    let _64px = 64
-//    let _80px = 80
-//    let _120px = 120
-//    let _156px = 156
-//}
-//
-//class Constants {
-//    static let spaceGuide: SpaceGuide = SpaceGuide()
-//}
+/// 추후 SpaceGuide 변경점 추가
+class Constants {
+    static let spaceGuide = SpaceGuide()
+}
 
 /// Padding 값
-enum SpaceGuide {
-    static let _4px = 4
-    static let _8px = 8
-    static let _12px = 12
-    static let _16px = 16
-    static let _20px = 20
-    static let _24px = 24
-    static let _28px = 28
-    static let _32px = 32
-    static let _36px = 36
-    static let _40px = 40
-    static let _48px = 48
-    static let _64px = 64
-    static let _80px = 80
-    static let _120px = 120
-    static let _156px = 156
+struct SpaceGuide {
+    let _4px = 4
+    let _8px = 8
+    let _12px = 12
+    let _16px = 16
+    let _20px = 20
+    let _24px = 24
+    let _28px = 28
+    let _32px = 32
+    let _36px = 36
+    let _40px = 40
+    let _48px = 48
+    let _64px = 64
+    let _80px = 80
+    let _120px = 120
+    let _156px = 156
 }

--- a/PopPool/PopPool/Presentation/Components/ButtonCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ButtonCPNT.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTButton.swift
+//  ButtonCPNT.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/20/24.
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 import SnapKit
 
-enum TYPEButton {
+enum ButtonTYPE {
     case primary
     case secondary
     case kakao
@@ -17,7 +17,7 @@ enum TYPEButton {
     case dft // Default
 }
 
-extension TYPEButton {
+extension ButtonTYPE {
     
     var backGroundColor: UIColor {
         switch self {
@@ -70,7 +70,7 @@ extension TYPEButton {
     }
 }
 
-final class CMPTButton: UIButton {
+final class ButtonCPNT: UIButton {
     
     lazy var iconImageView: UIImageView = {
         let view = UIImageView()
@@ -78,7 +78,7 @@ final class CMPTButton: UIButton {
         return view
     }()
     
-    init(type: TYPEButton, title: String, disabledTitle: String = "") {
+    init(type: ButtonTYPE, title: String, disabledTitle: String = "") {
         super.init(frame: .zero)
         self.setTitle(title, for: .normal)
         self.titleLabel?.font = type.font
@@ -94,7 +94,7 @@ final class CMPTButton: UIButton {
     }
 }
 
-private extension CMPTButton {
+private extension ButtonCPNT {
     
     /// Layer 설정
     func setUpLayer() {
@@ -105,7 +105,7 @@ private extension CMPTButton {
     
     /// 각 타입별 버튼 설정
     /// - Parameter type: TYPEButton
-    func setUpButtonType(type: TYPEButton) {
+    func setUpButtonType(type: ButtonTYPE) {
         self.backgroundColor = type.backGroundColor
         self.setTitleColor(type.titleColor, for: .normal)
         

--- a/PopPool/PopPool/Presentation/Components/ContentTitleCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ContentTitleCPNT.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTContentTitle.swift
+//  ContentTitleCPNT.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/25/24.
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 
 // 제목 타입 열거형 정의
-enum TYPEContentTitle {
+enum ContentTitleTYPE {
     case title_sub_fp(subTitle: String)
     case title_fp
     case title_icon_fp(icon: UIImage?)
@@ -19,7 +19,7 @@ enum TYPEContentTitle {
 }
 
 // 제목 타입 확장
-extension TYPEContentTitle {
+extension ContentTitleTYPE {
     // 제목 폰트 설정
     var titleFont: UIFont? {
         switch self {
@@ -65,7 +65,7 @@ extension TYPEContentTitle {
     }
 }
 
-final class CMPTContentTitle: UIStackView {
+final class ContentTitleCPNT: UIStackView {
     
     // MARK: - Components
     private let titleLabel: UILabel = {
@@ -97,7 +97,7 @@ final class CMPTContentTitle: UIStackView {
         return view
     }()
     
-    init(title: String, type: TYPEContentTitle) {
+    init(title: String, type: ContentTitleTYPE) {
         super.init(frame: .zero)
         setUp(title: title, type: type)
         setUpViewType(type: type)
@@ -108,13 +108,13 @@ final class CMPTContentTitle: UIStackView {
     }
 }
 
-private extension CMPTContentTitle {
+private extension ContentTitleCPNT {
     
     /// 기본 설정 메소드
     /// - Parameters:
     ///   - title: 제목
     ///   - type: TYPEContentTitle
-    func setUp(title: String, type: TYPEContentTitle) {
+    func setUp(title: String, type: ContentTitleTYPE) {
         self.axis = .vertical
         self.spacing = 0
         self.alignment = .fill
@@ -134,7 +134,7 @@ private extension CMPTContentTitle {
     
     /// 뷰 타입별 설정 메소드
     /// - Parameter type: TYPEContentTitle
-    func setUpViewType(type: TYPEContentTitle) {
+    func setUpViewType(type: ContentTitleTYPE) {
         let topSpacingView = UIView()
         let middleSpacingView = UIView()
         
@@ -143,10 +143,10 @@ private extension CMPTContentTitle {
             subTitleLabel.text = subTitle
             
             topSpacingView.snp.makeConstraints { make in
-                make.height.equalTo(SpaceGuide._64px)
+                make.height.equalTo(Constants.spaceGuide._64px)
             }
             middleSpacingView.snp.makeConstraints { make in
-                make.height.equalTo(SpaceGuide._16px)
+                make.height.equalTo(Constants.spaceGuide._16px)
             }
             
             self.addArrangedSubview(topSpacingView)
@@ -155,7 +155,7 @@ private extension CMPTContentTitle {
             self.addArrangedSubview(subTitleLabel)
         case .title_fp:
             topSpacingView.snp.makeConstraints { make in
-                make.height.equalTo(SpaceGuide._64px)
+                make.height.equalTo(Constants.spaceGuide._64px)
             }
             
             self.addArrangedSubview(topSpacingView)
@@ -166,11 +166,11 @@ private extension CMPTContentTitle {
             subStackView.spacing = 10
             
             topSpacingView.snp.makeConstraints { make in
-                make.height.equalTo(SpaceGuide._64px)
+                make.height.equalTo(Constants.spaceGuide._64px)
             }
 
             iconImageView.snp.makeConstraints { make in
-                make.size.equalTo(SpaceGuide._24px)
+                make.size.equalTo(Constants.spaceGuide._24px)
             }
             
             subStackView.addArrangedSubview(titleLabel)
@@ -182,10 +182,10 @@ private extension CMPTContentTitle {
             button.setImage(buttonImage, for: .normal)
             
             topSpacingView.snp.makeConstraints { make in
-                make.height.equalTo(SpaceGuide._32px)
+                make.height.equalTo(Constants.spaceGuide._32px)
             }
             middleSpacingView.snp.makeConstraints { make in
-                make.height.equalTo(SpaceGuide._8px)
+                make.height.equalTo(Constants.spaceGuide._8px)
             }
             button.snp.makeConstraints { make in
                 make.size.equalTo(24)
@@ -201,7 +201,7 @@ private extension CMPTContentTitle {
             button.setImage(buttonImage, for: .normal)
             
             topSpacingView.snp.makeConstraints { make in
-                make.height.equalTo(SpaceGuide._32px)
+                make.height.equalTo(Constants.spaceGuide._32px)
             }
             button.snp.makeConstraints { make in
                 make.size.equalTo(24)
@@ -215,7 +215,7 @@ private extension CMPTContentTitle {
     }
 }
 
-extension CMPTContentTitle {
+extension ContentTitleCPNT {
     /// 제목 attributedText설정
     /// - Parameter attributedText: NSAttributedString 값
     func setTitleLabel(attributedText: NSAttributedString) {

--- a/PopPool/PopPool/Presentation/Components/ProgressIndicatorCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ProgressIndicatorCPNT.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTProgressIndicator.swift
+//  ProgressIndicatorCPNT.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/23/24.
@@ -12,10 +12,10 @@ import RxSwift
 import RxCocoa
 
 
-final class CMPTProgressIndicator: UIStackView {
+final class ProgressIndicatorCPNT: UIStackView {
     
     // MARK: - Properties
-    private var progressViews: [CMTPProgressView]
+    private var progressViews: [ProgressViewCPNT]
     private var progressIndex: Int
     
     /// 전체 단계 수와 시작 지점을 기반으로 CMPTProgressIndicator를 초기화
@@ -24,7 +24,7 @@ final class CMPTProgressIndicator: UIStackView {
     ///   - startPoint: 초기 시작 지점 (1부터 시작하는 인덱스)
     init(totalStep: Int, startPoint: Int) {
         self.progressViews = (1...totalStep).map({ index in
-            return CMTPProgressView(isSelected: index == startPoint)
+            return ProgressViewCPNT(isSelected: index == startPoint)
         })
         self.progressIndex = startPoint
         super.init(frame: .zero)
@@ -38,7 +38,7 @@ final class CMPTProgressIndicator: UIStackView {
 }
 
 // MARK: - SetUp
-private extension CMPTProgressIndicator {
+private extension ProgressIndicatorCPNT {
     
     /// 스택 뷰 속성 설정
     func setUp() {
@@ -55,7 +55,7 @@ private extension CMPTProgressIndicator {
     }
 }
 
-extension CMPTProgressIndicator {
+extension ProgressIndicatorCPNT {
     
     /// 진행 인디케이터를 한 단계 앞으로 이동
     func increaseIndicator() {

--- a/PopPool/PopPool/Presentation/Components/ProgressViewCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ProgressViewCPNT.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTProgressView.swift
+//  ProgressViewCPNT.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/23/24.
@@ -9,11 +9,11 @@ import Foundation
 import UIKit
 import SnapKit
 
-final class CMTPProgressView: UIView {
+final class ProgressViewCPNT: UIView {
     
     
     /// CMTPProgressView Animation Type
-    enum CMTPProgressFillAnimation {
+    enum ProgressFillAnimationCPNT {
         case fromLeft
         case fromRight
     }
@@ -48,7 +48,7 @@ final class CMTPProgressView: UIView {
 }
 
 // MARK: - SetUp
-private extension CMTPProgressView {
+private extension ProgressViewCPNT {
     
     /// 뷰 설정
     func setUp() {
@@ -74,11 +74,11 @@ private extension CMTPProgressView {
     }
 }
 
-extension CMTPProgressView {
+extension ProgressViewCPNT {
     
     /// 선택된 뷰를 채우는 애니메이션
     /// - Parameter option: 애니메이션 시작 방향
-    func fillAnimation(option: CMTPProgressFillAnimation) {
+    func fillAnimation(option: ProgressFillAnimationCPNT) {
         let viewWitdh = self.frame.width
         switch option {
         case .fromLeft:
@@ -116,7 +116,7 @@ extension CMTPProgressView {
     
     /// 선택된 뷰를 사라지게 하는 애니메이션
     /// - Parameter option: 애니메이션 시작 방향
-    func disappearAnimation(option: CMTPProgressFillAnimation) {
+    func disappearAnimation(option: ProgressFillAnimationCPNT) {
         let viewWitdh = self.frame.width
         switch option {
         case .fromLeft:

--- a/PopPool/PopPool/Presentation/Components/ToastMSGCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ToastMSGCPNT.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTToastMSG.swift
+//  ToastMSGCPNT.swift
 //  PopPool
 //
 //  Created by Porori on 6/24/24.
@@ -10,7 +10,7 @@ import SnapKit
 import UIKit
 
 /// 토스트 메시지를 담는 view 객체입니다
-final class CMPTToastMSG: UIView {
+final class ToastMSGCPNT: UIView {
     
     // MARK: - Properties
     
@@ -45,7 +45,7 @@ final class CMPTToastMSG: UIView {
     }
 }
 
-extension CMPTToastMSG {
+extension ToastMSGCPNT {
     
     // MARK: - Method
     

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Components/CheckBoxCPNT.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Components/CheckBoxCPNT.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTCheckBox.swift
+//  CheckBoxCPNT.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/25/24.
@@ -11,7 +11,7 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-final class CMPTCheckBox: UIButton {
+final class CheckBoxCPNT: UIButton {
     
     // MARK: - Components
     private let contentLabel: UILabel = {
@@ -52,7 +52,7 @@ final class CMPTCheckBox: UIButton {
 }
 
 // MARK: - SetUp
-private extension CMPTCheckBox {
+private extension CheckBoxCPNT {
     
     /// 뷰 설정
     func setUp() {
@@ -72,8 +72,8 @@ private extension CMPTCheckBox {
         stackView.addArrangedSubview(contentLabel)
         self.addSubview(stackView)
         stackView.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(SpaceGuide._20px)
-            make.top.bottom.equalToSuperview().inset(SpaceGuide._12px)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
+            make.top.bottom.equalToSuperview().inset(Constants.spaceGuide._12px)
         }
     }
     

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Components/TermsViewCPNT.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Components/TermsViewCPNT.swift
@@ -1,5 +1,5 @@
 //
-//  CMPTTermsView.swift
+//  TermsViewCPNT.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/25/24.
@@ -11,7 +11,7 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-final class CMPTTermsView: UIStackView {
+final class TermsViewCPNT: UIStackView {
     
     // MARK: - Components
     private let checkButton: UIButton = {
@@ -57,7 +57,7 @@ final class CMPTTermsView: UIStackView {
     
 }
 // MARK: - SetUp
-private extension CMPTTermsView {
+private extension TermsViewCPNT {
     
     /// 뷰 설정
     func setUp() {

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/VCSignUp.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/VCSignUp.swift
@@ -13,23 +13,23 @@ import RxSwift
 
 final class VCSignUp: UIViewController {
     
-    private let progressIndicator: CMPTProgressIndicator = CMPTProgressIndicator(totalStep: 4, startPoint: 1)
+    private let progressIndicator: ProgressIndicatorCPNT = ProgressIndicatorCPNT(totalStep: 4, startPoint: 1)
     
     // MARK: - ContentTitles
-    private var contentTitleViews: [CMPTContentTitle] = [
-        CMPTContentTitle(
+    private var contentTitleViews: [ContentTitleCPNT] = [
+        ContentTitleCPNT(
             title: "서비스 이용을 위한\n약관을 확인해주세요",
             type: .title_fp
         ),
-        CMPTContentTitle(
+        ContentTitleCPNT(
             title: "팝풀에서 사용할\n별명을 설정해볼까요?",
             type: .title_sub_fp(subTitle: "이 단계를 건너뛰시면 자동으로 별명이 만들어져요.")
         ),
-        CMPTContentTitle(
+        ContentTitleCPNT(
             title: "$유저명$님에 대해\n조금 더 알려주시겠어요?",
             type: .title_fp
         ),
-        CMPTContentTitle(
+        ContentTitleCPNT(
             title: "$유저명$님에 대해\n조금 더 알려주시겠어요?",
             type: .title_fp
         )
@@ -45,8 +45,8 @@ final class VCSignUp: UIViewController {
     private let contentStackView: UIStackView = UIStackView()
     
     // MARK: - Buttons
-    private let step1_primaryButton: CMPTButton = {
-        let button = CMPTButton(
+    private let step1_primaryButton: ButtonCPNT = {
+        let button = ButtonCPNT(
             type: .primary,
             title: "확인",
             disabledTitle: "확인"
@@ -54,24 +54,24 @@ final class VCSignUp: UIViewController {
         button.isEnabled = false
         return button
     }()
-    private let step2_primaryButton = CMPTButton(type: .primary, title: "확인", disabledTitle: "다음")
-    private let step2_secondaryButton = CMPTButton(type: .secondary, title: "건너뛰기")
+    private let step2_primaryButton = ButtonCPNT(type: .primary, title: "확인", disabledTitle: "다음")
+    private let step2_secondaryButton = ButtonCPNT(type: .secondary, title: "건너뛰기")
     lazy var step2_buttons: UIStackView = {
         let view = UIStackView(arrangedSubviews: [self.step2_secondaryButton, self.step2_primaryButton])
         view.spacing = 10
         view.distribution = .fillEqually
         return view
     }()
-    private let step3_primaryButton = CMPTButton(type: .primary, title: "다음", disabledTitle: "다음")
-    private let step3_secondaryButton = CMPTButton(type: .secondary, title: "건너뛰기")
+    private let step3_primaryButton = ButtonCPNT(type: .primary, title: "다음", disabledTitle: "다음")
+    private let step3_secondaryButton = ButtonCPNT(type: .secondary, title: "건너뛰기")
     lazy var step3_buttons: UIStackView = {
         let view = UIStackView(arrangedSubviews: [self.step3_secondaryButton, self.step3_primaryButton])
         view.spacing = 10
         view.distribution = .fillEqually
         return view
     }()
-    private let step4_primaryButton = CMPTButton(type: .primary, title: "다음", disabledTitle: "다음")
-    private let step4_secondaryButton = CMPTButton(type: .secondary, title: "건너뛰기")
+    private let step4_primaryButton = ButtonCPNT(type: .primary, title: "다음", disabledTitle: "다음")
+    private let step4_secondaryButton = ButtonCPNT(type: .secondary, title: "건너뛰기")
     lazy var step4_buttons: UIStackView = {
         let view = UIStackView(arrangedSubviews: [self.step4_secondaryButton, self.step4_primaryButton])
         view.spacing = 10
@@ -114,21 +114,21 @@ private extension VCSignUp {
         view.addSubview(buttonStackView)
         
         progressIndicator.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).inset(SpaceGuide._16px)
-            make.leading.trailing.equalToSuperview().inset(SpaceGuide._20px)
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(Constants.spaceGuide._16px)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
         }
         contentTitleStackView.snp.makeConstraints { make in
             make.top.equalTo(progressIndicator.snp.bottom)
-            make.leading.trailing.equalToSuperview().inset(SpaceGuide._20px)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
         }
         contentStackView.snp.makeConstraints { make in
             make.top.equalTo(contentTitleStackView.snp.bottom)
-            make.leading.trailing.equalToSuperview().inset(SpaceGuide._20px)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
         }
         buttonStackView.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(SpaceGuide._20px)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
             make.height.equalTo(52)
-            make.bottom.equalToSuperview().inset(SpaceGuide._48px)
+            make.bottom.equalToSuperview().inset(Constants.spaceGuide._48px)
         }
     }
     

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/VMSignUp.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/VMSignUp.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-final class VMSignUp: ViewModel {
+final class VMSignUp: ViewModelable {
     
     /// 입력 이벤트
     struct Input {

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep1View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep1View.swift
@@ -15,11 +15,11 @@ final class SignUpStep1View: UIStackView {
     // MARK: - Components
     private let topSpacingView = UIView()
     private let middleSpacingView = UIView()
-    private let checkBox = CMPTCheckBox(title: "약관에 모두 동의할게요")
-    private let term1View = CMPTTermsView(title: "[필수] 이용약관")
-    private let term2View = CMPTTermsView(title: "[필수] 개인정보 수집 및 이용")
-    private let term3View = CMPTTermsView(title: "[필수] 만 14세 이상")
-    private let term4View = CMPTTermsView(title: "[선택] 광고성 정보 수신")
+    private let checkBox = CheckBoxCPNT(title: "약관에 모두 동의할게요")
+    private let term1View = TermsViewCPNT(title: "[필수] 이용약관")
+    private let term2View = TermsViewCPNT(title: "[필수] 개인정보 수집 및 이용")
+    private let term3View = TermsViewCPNT(title: "[필수] 만 14세 이상")
+    private let term4View = TermsViewCPNT(title: "[선택] 광고성 정보 수신")
     private let termsStackView: UIStackView = {
         let view = UIStackView()
         view.axis = .vertical
@@ -55,10 +55,10 @@ private extension SignUpStep1View {
     /// 제약 조건 설정
     func setUpConstraints() {
         topSpacingView.snp.makeConstraints { make in
-            make.height.equalTo(SpaceGuide._48px)
+            make.height.equalTo(Constants.spaceGuide._48px)
         }
         middleSpacingView.snp.makeConstraints { make in
-            make.height.equalTo(SpaceGuide._36px)
+            make.height.equalTo(Constants.spaceGuide._36px)
         }
         termsStackView.addArrangedSubview(term1View)
         termsStackView.addArrangedSubview(term2View)


### PR DESCRIPTION
## Description
- 오해의 소지가 발생할 수 있어 타입명칭을 변경
- 타입이외에 Interface, Components, Enum, Constants 등 또한 수정 완료

## Changes
- 기존 합의한 CMPTToastMSG, TYPEButton 같은 타입 명칭에서 ToastMSGCPNT, ButtonTYPE으로 수정 진행
*ViewController, ViewModel 등 scene에 필요한 파일 생성이 되며 네이밍으로 인한 오해 증가, 가독성을 헤치는 이슈로 함께 리팩토링 진행*