### PR TITLE
[MERGE] : ✅ SignUp Step 3 View, SegmentedControlCPNT

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		08C813D92C2D294D009239FE /* UICollectionViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813D82C2D294D009239FE /* UICollectionViewCell+.swift */; };
 		08C813DB2C2D3A58009239FE /* LargeChipCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813DA2C2D3A58009239FE /* LargeChipCell.swift */; };
 		08C813DE2C2D50BC009239FE /* TagsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813DD2C2D50BC009239FE /* TagsLayout.swift */; };
+		08C813E02C2D82EF009239FE /* SegmentedControlCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813DF2C2D82EF009239FE /* SegmentedControlCPNT.swift */; };
+		08C813E22C2D8AA2009239FE /* SignUpStep4View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813E12C2D8AA2009239FE /* SignUpStep4View.swift */; };
 		08F49DDB2C200528002D5202 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DDA2C200528002D5202 /* AuthService.swift */; };
 		08F49DE82C231C40002D5202 /* SocialTYPE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE72C231C40002D5202 /* SocialTYPE.swift */; };
 		08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE92C231CFC002D5202 /* LoginResponse.swift */; };
@@ -152,6 +154,8 @@
 		08C813D82C2D294D009239FE /* UICollectionViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+.swift"; sourceTree = "<group>"; };
 		08C813DA2C2D3A58009239FE /* LargeChipCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeChipCell.swift; sourceTree = "<group>"; };
 		08C813DD2C2D50BC009239FE /* TagsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsLayout.swift; sourceTree = "<group>"; };
+		08C813DF2C2D82EF009239FE /* SegmentedControlCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlCPNT.swift; sourceTree = "<group>"; };
+		08C813E12C2D8AA2009239FE /* SignUpStep4View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStep4View.swift; sourceTree = "<group>"; };
 		08F49DDA2C200528002D5202 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		08F49DE72C231C40002D5202 /* SocialTYPE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialTYPE.swift; sourceTree = "<group>"; };
 		08F49DE92C231CFC002D5202 /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
@@ -424,6 +428,7 @@
 			children = (
 				08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */,
 				08C813D42C2D1F5E009239FE /* SignUpStep3View.swift */,
+				08C813E12C2D8AA2009239FE /* SignUpStep4View.swift */,
 				08C813DA2C2D3A58009239FE /* LargeChipCell.swift */,
 			);
 			path = Views;
@@ -547,6 +552,7 @@
 				08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */,
 				BD9901CC2C2877BF0024F30D /* ToastMSGCPNT.swift */,
 				08A28CB52C2A97E300DF7A90 /* ContentTitleCPNT.swift */,
+				08C813DF2C2D82EF009239FE /* SegmentedControlCPNT.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -864,6 +870,7 @@
 				BDF3B2C12C0C318E00B079C5 /* Responsable.swift in Sources */,
 				08C813D72C2D2934009239FE /* UITableViewCell+.swift in Sources */,
 				085105A02C1038EB00ED7DBB /* AuthError.swift in Sources */,
+				08C813E02C2D82EF009239FE /* SegmentedControlCPNT.swift in Sources */,
 				BDF3B2AA2C0BE23D00B079C5 /* Requestable.swift in Sources */,
 				08A28CC82C2BE1F300DF7A90 /* Outputable.swift in Sources */,
 				08F49DDB2C200528002D5202 /* AuthService.swift in Sources */,
@@ -905,6 +912,7 @@
 				BDF4F2962C240B95002F4F03 /* UIColor+.swift in Sources */,
 				BDD335202C0B6ACA002C2295 /* EndPoint.swift in Sources */,
 				08F49DF62C2323C2002D5202 /* AuthUseCaseImpl.swift in Sources */,
+				08C813E22C2D8AA2009239FE /* SignUpStep4View.swift in Sources */,
 				08F49DEC2C231D13002D5202 /* LoginResponseDTO.swift in Sources */,
 				BDC622B52C2294D4009411AE /* LocalSaveUseCaseImpl.swift in Sources */,
 			);

--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -36,11 +36,11 @@
 		0873465A2C0AED6C00534FFA /* AppDIContainerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346592C0AED6C00534FFA /* AppDIContainerTest.swift */; };
 		0873465B2C0AEFCF00534FFA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087346102C0AAD2900534FFA /* AppDelegate.swift */; };
 		087A68B12C1ECEBC00CF3631 /* LocalDBUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087A68B02C1ECEBC00CF3631 /* LocalDBUseCase.swift */; };
-		08A28CAA2C27E16F00DF7A90 /* VCSignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CA92C27E16F00DF7A90 /* VCSignUp.swift */; };
+		08A28CAA2C27E16F00DF7A90 /* SignUpVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CA92C27E16F00DF7A90 /* SignUpVC.swift */; };
 		08A28CAC2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CAB2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift */; };
 		08A28CB42C280F9600DF7A90 /* ProgressViewCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */; };
 		08A28CB62C2A97E300DF7A90 /* ContentTitleCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB52C2A97E300DF7A90 /* ContentTitleCPNT.swift */; };
-		08A28CBA2C2AC44300DF7A90 /* VMSignUp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB92C2AC44300DF7A90 /* VMSignUp.swift */; };
+		08A28CBA2C2AC44300DF7A90 /* SignUpVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB92C2AC44300DF7A90 /* SignUpVM.swift */; };
 		08A28CBE2C2AEAF600DF7A90 /* CheckBoxCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CBD2C2AEAF600DF7A90 /* CheckBoxCPNT.swift */; };
 		08A28CC22C2AF2DD00DF7A90 /* SignUpStep1View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */; };
 		08A28CC42C2B00B700DF7A90 /* TermsViewCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CC32C2B00B700DF7A90 /* TermsViewCPNT.swift */; };
@@ -50,6 +50,11 @@
 		08B9658A2C15FEBF00BF95AA /* FetchUserCredentialUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B965892C15FEBF00BF95AA /* FetchUserCredentialUseCaseImpl.swift */; };
 		08B9658C2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9658B2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift */; };
 		08B9658F2C16004D00BF95AA /* PopPoolAPIEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B9658E2C16004D00BF95AA /* PopPoolAPIEndPoint.swift */; };
+		08C813D52C2D1F5E009239FE /* SignUpStep3View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813D42C2D1F5E009239FE /* SignUpStep3View.swift */; };
+		08C813D72C2D2934009239FE /* UITableViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813D62C2D2934009239FE /* UITableViewCell+.swift */; };
+		08C813D92C2D294D009239FE /* UICollectionViewCell+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813D82C2D294D009239FE /* UICollectionViewCell+.swift */; };
+		08C813DB2C2D3A58009239FE /* LargeChipCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813DA2C2D3A58009239FE /* LargeChipCell.swift */; };
+		08C813DE2C2D50BC009239FE /* TagsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813DD2C2D50BC009239FE /* TagsLayout.swift */; };
 		08F49DDB2C200528002D5202 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DDA2C200528002D5202 /* AuthService.swift */; };
 		08F49DE82C231C40002D5202 /* SocialTYPE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE72C231C40002D5202 /* SocialTYPE.swift */; };
 		08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE92C231CFC002D5202 /* LoginResponse.swift */; };
@@ -127,11 +132,11 @@
 		087346552C0AEBD900534FFA /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
 		087346592C0AED6C00534FFA /* AppDIContainerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainerTest.swift; sourceTree = "<group>"; };
 		087A68B02C1ECEBC00CF3631 /* LocalDBUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBUseCase.swift; sourceTree = "<group>"; };
-		08A28CA92C27E16F00DF7A90 /* VCSignUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VCSignUp.swift; sourceTree = "<group>"; };
+		08A28CA92C27E16F00DF7A90 /* SignUpVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVC.swift; sourceTree = "<group>"; };
 		08A28CAB2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorCPNT.swift; sourceTree = "<group>"; };
 		08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewCPNT.swift; sourceTree = "<group>"; };
 		08A28CB52C2A97E300DF7A90 /* ContentTitleCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTitleCPNT.swift; sourceTree = "<group>"; };
-		08A28CB92C2AC44300DF7A90 /* VMSignUp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSignUp.swift; sourceTree = "<group>"; };
+		08A28CB92C2AC44300DF7A90 /* SignUpVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVM.swift; sourceTree = "<group>"; };
 		08A28CBD2C2AEAF600DF7A90 /* CheckBoxCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBoxCPNT.swift; sourceTree = "<group>"; };
 		08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStep1View.swift; sourceTree = "<group>"; };
 		08A28CC32C2B00B700DF7A90 /* TermsViewCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewCPNT.swift; sourceTree = "<group>"; };
@@ -142,6 +147,11 @@
 		08B965892C15FEBF00BF95AA /* FetchUserCredentialUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserCredentialUseCaseImpl.swift; sourceTree = "<group>"; };
 		08B9658B2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserCredentialUseCase.swift; sourceTree = "<group>"; };
 		08B9658E2C16004D00BF95AA /* PopPoolAPIEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolAPIEndPoint.swift; sourceTree = "<group>"; };
+		08C813D42C2D1F5E009239FE /* SignUpStep3View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpStep3View.swift; sourceTree = "<group>"; };
+		08C813D62C2D2934009239FE /* UITableViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+.swift"; sourceTree = "<group>"; };
+		08C813D82C2D294D009239FE /* UICollectionViewCell+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+.swift"; sourceTree = "<group>"; };
+		08C813DA2C2D3A58009239FE /* LargeChipCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeChipCell.swift; sourceTree = "<group>"; };
+		08C813DD2C2D50BC009239FE /* TagsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsLayout.swift; sourceTree = "<group>"; };
 		08F49DDA2C200528002D5202 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		08F49DE72C231C40002D5202 /* SocialTYPE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialTYPE.swift; sourceTree = "<group>"; };
 		08F49DE92C231CFC002D5202 /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
@@ -364,6 +374,7 @@
 		0873464F2C0ABC2300534FFA /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				08C813DC2C2D50AD009239FE /* Layout */,
 				BD0B8F512C26D59600FFBC24 /* Manager */,
 				BDF4F2942C240B86002F4F03 /* Utility */,
 				BDF4F2932C240B70002F4F03 /* Extension */,
@@ -412,6 +423,8 @@
 			isa = PBXGroup;
 			children = (
 				08A28CC12C2AF2DD00DF7A90 /* SignUpStep1View.swift */,
+				08C813D42C2D1F5E009239FE /* SignUpStep3View.swift */,
+				08C813DA2C2D3A58009239FE /* LargeChipCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -509,6 +522,14 @@
 			name = Repositories;
 			sourceTree = "<group>";
 		};
+		08C813DC2C2D50AD009239FE /* Layout */ = {
+			isa = PBXGroup;
+			children = (
+				08C813DD2C2D50BC009239FE /* TagsLayout.swift */,
+			);
+			path = Layout;
+			sourceTree = "<group>";
+		};
 		08F49DE62C231C30002D5202 /* Enums */ = {
 			isa = PBXGroup;
 			children = (
@@ -569,8 +590,8 @@
 			children = (
 				08A28CC02C2AF2C100DF7A90 /* Components */,
 				08A28CBF2C2AF2B800DF7A90 /* Views */,
-				08A28CA92C27E16F00DF7A90 /* VCSignUp.swift */,
-				08A28CB92C2AC44300DF7A90 /* VMSignUp.swift */,
+				08A28CA92C27E16F00DF7A90 /* SignUpVC.swift */,
+				08A28CB92C2AC44300DF7A90 /* SignUpVM.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -640,6 +661,8 @@
 			children = (
 				BDF4F2952C240B95002F4F03 /* UIColor+.swift */,
 				BDF4F29B2C2422DF002F4F03 /* UIFont+.swift */,
+				08C813D62C2D2934009239FE /* UITableViewCell+.swift */,
+				08C813D82C2D294D009239FE /* UICollectionViewCell+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -839,6 +862,7 @@
 				08B9658C2C15FF0600BF95AA /* FetchUserCredentialUseCase.swift in Sources */,
 				BDF4F29C2C2422DF002F4F03 /* UIFont+.swift in Sources */,
 				BDF3B2C12C0C318E00B079C5 /* Responsable.swift in Sources */,
+				08C813D72C2D2934009239FE /* UITableViewCell+.swift in Sources */,
 				085105A02C1038EB00ED7DBB /* AuthError.swift in Sources */,
 				BDF3B2AA2C0BE23D00B079C5 /* Requestable.swift in Sources */,
 				08A28CC82C2BE1F300DF7A90 /* Outputable.swift in Sources */,
@@ -846,8 +870,11 @@
 				08F49DF92C24006F002D5202 /* ToastMSGManager.swift in Sources */,
 				08F49E0F2C240A64002D5202 /* LocalFetchUseCaseImpl.swift in Sources */,
 				BD2E90F52C1B17C200BB0313 /* KeyChainRepositoryImpl.swift in Sources */,
+				08C813DB2C2D3A58009239FE /* LargeChipCell.swift in Sources */,
 				BDC622B12C225817009411AE /* DatabaseError.swift in Sources */,
+				08C813D92C2D294D009239FE /* UICollectionViewCell+.swift in Sources */,
 				08A28CB62C2A97E300DF7A90 /* ContentTitleCPNT.swift in Sources */,
+				08C813D52C2D1F5E009239FE /* SignUpStep3View.swift in Sources */,
 				087346562C0AEBD900534FFA /* AppDIContainer.swift in Sources */,
 				08F49DF22C23230C002D5202 /* AuthRepository.swift in Sources */,
 				BDF4F2982C240BA6002F4F03 /* Constants.swift in Sources */,
@@ -866,10 +893,11 @@
 				08A28CB42C280F9600DF7A90 /* ProgressViewCPNT.swift in Sources */,
 				08F49E092C240335002D5202 /* !_!_!_.swift in Sources */,
 				BDF3B2AE2C0BE69700B079C5 /* Provider.swift in Sources */,
-				08A28CBA2C2AC44300DF7A90 /* VMSignUp.swift in Sources */,
-				08A28CAA2C27E16F00DF7A90 /* VCSignUp.swift in Sources */,
+				08A28CBA2C2AC44300DF7A90 /* SignUpVM.swift in Sources */,
+				08A28CAA2C27E16F00DF7A90 /* SignUpVC.swift in Sources */,
 				08F49DF42C232364002D5202 /* AuthUseCase.swift in Sources */,
 				BD8607972C23418800726692 /* LocalDeleteUseCaseImpl.swift in Sources */,
+				08C813DE2C2D50BC009239FE /* TagsLayout.swift in Sources */,
 				BDB682552C1C316000560E7B /* LocalDBRepository.swift in Sources */,
 				08A28CC22C2AF2DD00DF7A90 /* SignUpStep1View.swift in Sources */,
 				08B9658A2C15FEBF00BF95AA /* FetchUserCredentialUseCaseImpl.swift in Sources */,

--- a/PopPool/PopPool/Application/SceneDelegate.swift
+++ b/PopPool/PopPool/Application/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let navigationController = UINavigationController()
         
 //        window?.rootViewController = UINavigationController(rootViewController: ViewController(viewModel: ViewControllerViewModel()))
-        window?.rootViewController = UINavigationController(rootViewController: VCSignUp())
+        window?.rootViewController = UINavigationController(rootViewController: SignUpVC())
         window?.makeKeyAndVisible()
     }
 

--- a/PopPool/PopPool/Presentation/Common/Extension/UICollectionViewCell+.swift
+++ b/PopPool/PopPool/Presentation/Common/Extension/UICollectionViewCell+.swift
@@ -1,0 +1,14 @@
+//
+//  UICollectionViewCell+.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/27/24.
+//
+
+import UIKit
+
+extension UICollectionViewCell {
+    static var identifier: String {
+        return String(describing: self)
+    }
+}

--- a/PopPool/PopPool/Presentation/Common/Extension/UITableViewCell+.swift
+++ b/PopPool/PopPool/Presentation/Common/Extension/UITableViewCell+.swift
@@ -1,0 +1,14 @@
+//
+//  UITableViewCell+.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/27/24.
+//
+
+import UIKit
+
+extension UITableViewCell {
+    static var identifier: String {
+        return String(describing: self)
+    }
+}

--- a/PopPool/PopPool/Presentation/Common/Layout/TagsLayout.swift
+++ b/PopPool/PopPool/Presentation/Common/Layout/TagsLayout.swift
@@ -1,0 +1,38 @@
+//
+//  TagsLayout.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/27/24.
+//
+
+import UIKit
+
+class TagsLayout: UICollectionViewFlowLayout {
+    
+    required override init() {super.init(); common()}
+    required init?(coder aDecoder: NSCoder) {super.init(coder: aDecoder); common()}
+    
+    private func common() {
+        estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        minimumLineSpacing = 10
+        minimumInteritemSpacing = 10
+    }
+    
+    override func layoutAttributesForElements(
+                    in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        
+        guard let att = super.layoutAttributesForElements(in:rect) else {return []}
+        var x: CGFloat = sectionInset.left
+        var y: CGFloat = -1.0
+        
+        for a in att {
+            if a.representedElementCategory != .cell { continue }
+            
+            if a.frame.origin.y >= y { x = sectionInset.left }
+            a.frame.origin.x = x
+            x += a.frame.width + minimumInteritemSpacing
+            y = a.frame.maxY
+        }
+        return att
+    }
+}

--- a/PopPool/PopPool/Presentation/Common/Layout/TagsLayout.swift
+++ b/PopPool/PopPool/Presentation/Common/Layout/TagsLayout.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 왼쪽 정렬 레이아웃
 class TagsLayout: UICollectionViewFlowLayout {
     
     required override init() {super.init(); common()}

--- a/PopPool/PopPool/Presentation/Components/SegmentedControlCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/SegmentedControlCPNT.swift
@@ -1,0 +1,137 @@
+//
+//  SegmentedControlCPNT.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/27/24.
+//
+
+import UIKit
+import SnapKit
+
+final class SegmentedControlCPNT: UISegmentedControl {
+    
+    /// 세그먼트 컨트롤 타입
+    enum SegmentedControlType {
+        case radio
+        case base
+        case tab
+    }
+    // MARK: - Components
+    private lazy var bottomLineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .g200
+        view.isHidden = true
+        self.addSubview(view)
+        return view
+    }()
+    private lazy var underlineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .blu500
+        view.isHidden = true
+        bottomLineView.addSubview(view)
+        return view
+    }()
+    
+    init(type: SegmentedControlType, segments: [String], selectedSegmentIndex: Int) {
+        super.init(frame: .zero)
+        setUpSegments(type: type, segments: segments)
+        self.selectedSegmentIndex = selectedSegmentIndex
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    /// 서브뷰 레이아웃 설정
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        //layout이 업데이트 될 때 underbar 업데이트
+        let underlineFinalXPosition = (self.bounds.width / CGFloat(self.numberOfSegments)) * CGFloat(self.selectedSegmentIndex)
+        self.underlineView.snp.updateConstraints { make in
+            make.leading.equalTo(underlineFinalXPosition)
+        }
+        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseOut) {
+            self.layoutIfNeeded()
+        }
+    }
+}
+
+// MARK: - SetUp
+private extension SegmentedControlCPNT {
+    
+    /// 세그먼트 설정 메서드
+    /// - Parameters:
+    ///   - type: 세그먼트 컨트롤 타입
+    ///   - segments: 세그먼트 타이틀 배열
+    func setUpSegments(type: SegmentedControlType, segments: [String]) {
+        let emptyImage = UIImage()
+        for seg in segments.reversed() {
+            self.insertSegment(withTitle: seg, at: 0, animated: true)
+        }
+        self.snp.makeConstraints { make in
+            make.height.equalTo(48)
+        }
+        // 디바이더 제거
+        self.setDividerImage(emptyImage, forLeftSegmentState: .normal, rightSegmentState: .normal, barMetrics: .default)
+        switch type {
+        case .radio:
+            // background color 변경이 g50값으로 변경이 되지 않아 subview에 접근하여 layer를 Hidden처리
+            for (index, view) in self.subviews.enumerated() {
+                if segments.count > index {
+                    view.layer.isHidden = true
+                }
+            }
+            self.selectedSegmentTintColor = .blu500
+            setFont(color: .w100, font: .KorFont(style: .bold, size: 15), state: .selected)
+            setFont(color: .g400, font: .KorFont(style: .medium, size: 15), state: .normal)
+        case .base:
+            // background color 변경이 g50값으로 변경이 되지 않아 subview에 접근하여 layer를 Hidden처리 하고 새로운 뷰를 덮어씌워서 색상을 적용
+            for (index, view) in self.subviews.enumerated() {
+                if segments.count > index {
+                    let bgView = UIView()
+                    view.addSubview(bgView)
+                    bgView.snp.makeConstraints { make in
+                        make.edges.equalToSuperview()
+                    }
+                    bgView.backgroundColor = .g50
+                }
+            }
+            self.selectedSegmentTintColor = .blu500
+            setFont(color: .w100, font: .KorFont(style: .bold, size: 15), state: .selected)
+            setFont(color: .g400, font: .KorFont(style: .medium, size: 14), state: .normal)
+        case .tab:
+            self.clipsToBounds = false
+            self.setBackgroundImage(emptyImage, for: .normal, barMetrics: .default)
+            self.setBackgroundImage(emptyImage, for: .selected, barMetrics: .default)
+            self.setBackgroundImage(emptyImage, for: .highlighted, barMetrics: .default)
+            bottomLineView.isHidden = false
+            underlineView.isHidden = false
+            bottomLineView.snp.makeConstraints { make in
+                make.height.equalTo(1)
+                make.leading.trailing.bottom.equalToSuperview()
+            }
+            underlineView.snp.makeConstraints { make in
+                make.width.equalTo(bottomLineView.snp.width).dividedBy(self.numberOfSegments)
+                make.height.equalTo(2)
+                make.bottom.equalTo(bottomLineView.snp.bottom)
+            }
+            setFont(color: .blu500, font: .KorFont(style: .bold, size: 15), state: .selected)
+            setFont(color: .g400, font: .KorFont(style: .medium, size: 15), state: .normal)
+        }
+    }
+    
+    /// 폰트 설정 메서드
+    /// - Parameters:
+    ///   - color: 폰트 색상
+    ///   - font: 폰트 스타일
+    ///   - state: 세그먼트 상태
+    func setFont(color: UIColor, font: UIFont?, state: UIControl.State) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 1.2
+        self.setTitleTextAttributes([
+            NSAttributedString.Key.foregroundColor: color,
+            NSAttributedString.Key.font: font!,
+            NSAttributedString.Key.paragraphStyle: paragraphStyle
+        ], for: state)
+    }
+}

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Components/CheckBoxCPNT.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Components/CheckBoxCPNT.swift
@@ -22,7 +22,6 @@ final class CheckBoxCPNT: UIButton {
     private let checkImageView: UIImageView = {
         let view = UIImageView()
         view.image = UIImage(named: "checkBox_disabled_signUp")
-        view.tintColor = .blue
         return view
     }()
     private let stackView: UIStackView = {

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
@@ -161,20 +161,21 @@ private extension SignUpVC {
             }
             .disposed(by: disposeBag)
         
-        output.fetchCategoryList
-            .withUnretained(self)
-            .subscribe { (owner, list) in
-                owner.step3View.setCategoryList(list: list)
-            }
-            .disposed(by: disposeBag)
-        
+        // Step 3 primary button 활성/비활성 상태 처리
         output.step3_primaryButton_isEnabled
             .withUnretained(self)
             .subscribe { (owner, isEnabled) in
                 owner.changeButtonState(button: owner.step3_primaryButton, isEnabled: isEnabled)
             }
             .disposed(by: disposeBag)
-
+        
+        // 카테고리 리스트 가져오기
+        output.fetchCategoryList
+            .withUnretained(self)
+            .subscribe { (owner, list) in
+                owner.step3View.setCategoryList(list: list)
+            }
+            .disposed(by: disposeBag)
     }
     
     /// 페이지 인덱스에 따라 뷰 변경을 처리하는 메서드

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
@@ -1,5 +1,5 @@
 //
-//  VCSignUp.swift
+//  SignUpVC.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/23/24.
@@ -11,7 +11,7 @@ import SnapKit
 import RxCocoa
 import RxSwift
 
-final class VCSignUp: UIViewController {
+final class SignUpVC: UIViewController {
     
     private let progressIndicator: ProgressIndicatorCPNT = ProgressIndicatorCPNT(totalStep: 4, startPoint: 1)
     
@@ -28,29 +28,24 @@ final class VCSignUp: UIViewController {
         ContentTitleCPNT(
             title: "$유저명$님에 대해\n조금 더 알려주시겠어요?",
             type: .title_fp
-        ),
-        ContentTitleCPNT(
-            title: "$유저명$님에 대해\n조금 더 알려주시겠어요?",
-            type: .title_fp
         )
     ]
     private let contentTitleStackView: UIStackView = UIStackView()
     
     // MARK: - ContentViews
     private let step1View = SignUpStep1View()
+    private let step3View = SignUpStep3View()
+
     lazy var contentViews = [
         step1View,
-        UIView()
+        UIView(),
+        step3View
     ]
     private let contentStackView: UIStackView = UIStackView()
     
     // MARK: - Buttons
     private let step1_primaryButton: ButtonCPNT = {
-        let button = ButtonCPNT(
-            type: .primary,
-            title: "확인",
-            disabledTitle: "확인"
-        )
+        let button = ButtonCPNT(type: .primary, title: "확인", disabledTitle: "확인")
         button.isEnabled = false
         return button
     }()
@@ -62,7 +57,11 @@ final class VCSignUp: UIViewController {
         view.distribution = .fillEqually
         return view
     }()
-    private let step3_primaryButton = ButtonCPNT(type: .primary, title: "다음", disabledTitle: "다음")
+    private let step3_primaryButton: ButtonCPNT = {
+        let button = ButtonCPNT(type: .primary, title: "다음", disabledTitle: "다음")
+        button.isEnabled = false
+        return button
+    }()
     private let step3_secondaryButton = ButtonCPNT(type: .secondary, title: "건너뛰기")
     lazy var step3_buttons: UIStackView = {
         let view = UIStackView(arrangedSubviews: [self.step3_secondaryButton, self.step3_primaryButton])
@@ -88,12 +87,12 @@ final class VCSignUp: UIViewController {
     private let buttonStackView: UIStackView = UIStackView()
     
     // MARK: - Properties
-    private let viewModel = VMSignUp()
+    private let viewModel = SignUpVM()
     private let disposeBag = DisposeBag()
 }
 
 // MARK: - Life Cycle
-extension VCSignUp {
+extension SignUpVC {
     override func viewDidLoad() {
         view.backgroundColor = .systemBackground
         setUpConstraints()
@@ -101,7 +100,7 @@ extension VCSignUp {
     }
 }
 // MARK: - SetUp
-private extension VCSignUp {
+private extension SignUpVC {
     
     /// UI 요소의 레이아웃 제약 설정
     func setUpConstraints() {
@@ -121,24 +120,27 @@ private extension VCSignUp {
             make.top.equalTo(progressIndicator.snp.bottom)
             make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
         }
-        contentStackView.snp.makeConstraints { make in
-            make.top.equalTo(contentTitleStackView.snp.bottom)
-            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
-        }
         buttonStackView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
             make.height.equalTo(52)
             make.bottom.equalToSuperview().inset(Constants.spaceGuide._48px)
         }
+        contentStackView.snp.makeConstraints { make in
+            make.top.equalTo(contentTitleStackView.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
+            make.bottom.equalTo(buttonStackView.snp.top)
+        }
+
     }
     
     /// ViewModel과의 바인딩을 설정
     func bind() {
-        let input = VMSignUp.Input(
+        let input = SignUpVM.Input(
             tap_step1_primaryButton: step1_primaryButton.rx.tap,
             tap_step2_primaryButton: step2_primaryButton.rx.tap,
             tap_step3_primaryButton: step3_primaryButton.rx.tap,
-            didChagneTerms: step1View.terms
+            didChangeTerms: step1View.terms,
+            didChangeInterestList: step3View.fetchSelectedList()
         )
         let output = viewModel.transform(input: input)
         
@@ -158,6 +160,21 @@ private extension VCSignUp {
                 owner.changeButtonState(button: owner.step1_primaryButton, isEnabled: isEnabled)
             }
             .disposed(by: disposeBag)
+        
+        output.fetchCategoryList
+            .withUnretained(self)
+            .subscribe { (owner, list) in
+                owner.step3View.setCategoryList(list: list)
+            }
+            .disposed(by: disposeBag)
+        
+        output.step3_primaryButton_isEnabled
+            .withUnretained(self)
+            .subscribe { (owner, isEnabled) in
+                owner.changeButtonState(button: owner.step3_primaryButton, isEnabled: isEnabled)
+            }
+            .disposed(by: disposeBag)
+
     }
     
     /// 페이지 인덱스에 따라 뷰 변경을 처리하는 메서드
@@ -167,19 +184,19 @@ private extension VCSignUp {
     ///   - previousIndex: 이전 페이지 인덱스
     func changeViewFrom(pageIndex: Int, previousIndex: Int) {
         if pageIndex < contentTitleViews.count {
-            UIView.transition(with: contentTitleStackView, duration: 0.2, options: .transitionFlipFromBottom) {
+            UIView.transition(with: contentTitleStackView, duration: 0.2, options: .transitionCrossDissolve) {
                 self.contentTitleViews[previousIndex].removeFromSuperview()
                 self.contentTitleStackView.addArrangedSubview(self.contentTitleViews[pageIndex])
             }
         }
         if pageIndex < contentViews.count {
-            UIView.transition(with: contentStackView, duration: 0.2, options: .transitionFlipFromBottom) {
+            UIView.transition(with: contentStackView, duration: 0.2, options: .transitionCrossDissolve) {
                 self.contentViews[previousIndex].removeFromSuperview()
                 self.contentStackView.addArrangedSubview(self.contentViews[pageIndex])
             }
         }
         if pageIndex < bottomButtons.count {
-            UIView.transition(with: buttonStackView, duration: 0.2, options: .transitionFlipFromBottom) {
+            UIView.transition(with: buttonStackView, duration: 0.2, options: .transitionCrossDissolve) {
                 self.bottomButtons[previousIndex].removeFromSuperview()
                 self.buttonStackView.addArrangedSubview(self.bottomButtons[pageIndex])
             }

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
@@ -35,11 +35,12 @@ final class SignUpVC: UIViewController {
     // MARK: - ContentViews
     private let step1View = SignUpStep1View()
     private let step3View = SignUpStep3View()
-
+    private let step4View = SignUpStep4View()
     lazy var contentViews = [
         step1View,
         UIView(),
-        step3View
+        step3View,
+        step4View
     ]
     private let contentStackView: UIStackView = UIStackView()
     

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
@@ -1,5 +1,5 @@
 //
-//  VMSignUp.swift
+//  SignUpVM.swift
 //  PopPool
 //
 //  Created by SeoJunYoung on 6/25/24.
@@ -9,8 +9,8 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-final class VMSignUp: ViewModelable {
-    
+final class SignUpVM: ViewModelable {
+
     /// 입력 이벤트
     struct Input {
         /// Sign Up Step1 primary button  탭 이벤트
@@ -20,7 +20,10 @@ final class VMSignUp: ViewModelable {
         /// Sign Up Step3 primary button  탭 이벤트
         var tap_step3_primaryButton: ControlEvent<Void>
         /// 약관 동의 변경을 전달하는 Subject
-        var didChagneTerms: PublishSubject<[Bool]>
+        var didChangeTerms: PublishSubject<[Bool]>
+        /// 관심사 변경을 전달하는 Subject
+        var didChangeInterestList: Observable<[String]>
+        
     }
     
     /// 출력 이벤트
@@ -29,6 +32,10 @@ final class VMSignUp: ViewModelable {
         var increasePageIndex: PublishSubject<Int>
         /// Step 1의 주요 버튼 활성/비활성 상태를 방출하는 Subject
         var step1_primaryButton_isEnabled: PublishSubject<Bool>
+
+        var fetchCategoryList: PublishSubject<[String]>
+        
+        var step3_primaryButton_isEnabled: PublishSubject<Bool>
     }
     
     var disposeBag: DisposeBag = DisposeBag()
@@ -44,9 +51,11 @@ final class VMSignUp: ViewModelable {
         
         let increasePageIndex: PublishSubject<Int> = .init()
         let step1_primaryButton_isEnabled: PublishSubject<Bool> = .init()
+        let step3_primaryButton_isEnabled: PublishSubject<Bool> = .init()
+        let fetchCategoryList: PublishSubject<[String]> = .init()
         
         // 약관 동의 변경 이벤트 처리
-        input.didChagneTerms.asObserver()
+        input.didChangeTerms.asObserver()
             .subscribe(onNext: { isCheck in
                 if isCheck[0] && isCheck[1] && isCheck[2] {
                     step1_primaryButton_isEnabled.onNext(true)
@@ -71,8 +80,36 @@ final class VMSignUp: ViewModelable {
             .subscribe { (owner, _) in
                 owner.pageIndex.accept(owner.pageIndex.value + 1)
                 increasePageIndex.onNext(owner.pageIndex.value)
+                fetchCategoryList.onNext([
+                    "패션",
+                    "라이프스타일",
+                    "뷰티",
+                    "음식/요리",
+                    "예술",
+                    "반려동물",
+                    "여행",
+                    "엔터테인먼트",
+                    "애니메이션",
+                    "키즈",
+                    "스포츠",
+                    "게임",
+                ])
             }
             .disposed(by: disposeBag)
+        
+        input.didChangeInterestList
+            .subscribe { list in
+            }
+            .disposed(by: disposeBag)
+        
+        input.didChangeInterestList
+            .subscribe { list in
+                step3_primaryButton_isEnabled.onNext(list.count > 0 ? true : false)
+            } onError: { error in
+                print("관심사 선택 중 알 수 없는 오류가 발생하였습니다.")
+            }
+            .disposed(by: disposeBag)
+
         
         // Step 3 primary button 탭 이벤트 처리
         input.tap_step3_primaryButton
@@ -85,7 +122,11 @@ final class VMSignUp: ViewModelable {
         
         return Output(
             increasePageIndex: increasePageIndex,
-            step1_primaryButton_isEnabled: step1_primaryButton_isEnabled
+            step1_primaryButton_isEnabled: step1_primaryButton_isEnabled,
+            fetchCategoryList: fetchCategoryList,
+            step3_primaryButton_isEnabled: step3_primaryButton_isEnabled
         )
     }
 }
+
+

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
@@ -30,11 +30,11 @@ final class SignUpVM: ViewModelable {
     struct Output {
         /// 페이지 인덱스 증가 이벤트를 방출하는 Subject
         var increasePageIndex: PublishSubject<Int>
-        /// Step 1의 주요 버튼 활성/비활성 상태를 방출하는 Subject
+        /// Step 1의 primary button 활성/비활성 상태를 방출하는 Subject
         var step1_primaryButton_isEnabled: PublishSubject<Bool>
-
+        /// 카테고리 리스트를 가져오는 Subject
         var fetchCategoryList: PublishSubject<[String]>
-        
+        /// Step 3의 primary button 활성/비활성 상태를 방출하는 Subject
         var step3_primaryButton_isEnabled: PublishSubject<Bool>
     }
     
@@ -97,11 +97,7 @@ final class SignUpVM: ViewModelable {
             }
             .disposed(by: disposeBag)
         
-        input.didChangeInterestList
-            .subscribe { list in
-            }
-            .disposed(by: disposeBag)
-        
+        // 관심사 리스트 변경 이벤트 처리
         input.didChangeInterestList
             .subscribe { list in
                 step3_primaryButton_isEnabled.onNext(list.count > 0 ? true : false)
@@ -110,7 +106,6 @@ final class SignUpVM: ViewModelable {
             }
             .disposed(by: disposeBag)
 
-        
         // Step 3 primary button 탭 이벤트 처리
         input.tap_step3_primaryButton
             .withUnretained(self)

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/LargeChipCell.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/LargeChipCell.swift
@@ -1,0 +1,74 @@
+//
+//  LargeChipCell.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/27/24.
+//
+
+import UIKit
+import SnapKit
+
+final class LargeChipCell: UICollectionViewCell {
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .bold, size: 13)
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUp()
+        setUpConstraints()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            UIView.transition(with: self.contentView, duration: 0.2, options: .transitionCrossDissolve) {
+                self.contentView.layer.borderWidth = self.isSelected ? 0 : 1
+                self.contentView.layer.borderColor = self.isSelected ? nil : UIColor.g200.cgColor
+                self.contentView.backgroundColor = self.isSelected ? .blu500 : .clear
+                self.label.textColor = self.isSelected ? .w100 : .g400
+            }
+        }
+    }
+}
+
+extension LargeChipCell {
+    
+    func setUp() {
+        self.contentView.layer.cornerRadius = contentView.frame.height / 2
+        self.contentView.layer.borderWidth = self.isSelected ? 0 : 1
+        self.contentView.layer.borderColor = self.isSelected ? nil : UIColor.g200.cgColor
+        self.contentView.backgroundColor = self.isSelected ? .blu500 : .clear
+        self.label.textColor = self.isSelected ? .w100 : .g400
+    }
+    
+    func setUpConstraints() {
+        contentView.addSubview(label)
+        label.snp.makeConstraints { make in
+            make.height.equalTo(18)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._16px)
+            make.top.equalToSuperview().inset(10)
+            make.bottom.equalToSuperview().inset(9)
+        }
+    }
+    
+    func configure(title: String?) {
+        label.text = title
+    }
+    
+    func adjustCellSize(title: String) -> CGSize {
+        let targetSize = CGSize(width: UIView.layoutFittingCompressedSize.width, height: UIView.layoutFittingCompressedSize.height)
+        return self.contentView.systemLayoutSizeFitting(
+            targetSize,
+            withHorizontalFittingPriority:.fittingSizeLevel,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+    }
+}

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/LargeChipCell.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/LargeChipCell.swift
@@ -10,6 +10,7 @@ import SnapKit
 
 final class LargeChipCell: UICollectionViewCell {
     
+    // MARK: - Components
     private let label: UILabel = {
         let label = UILabel()
         label.font = .KorFont(style: .bold, size: 13)
@@ -27,6 +28,7 @@ final class LargeChipCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 셀이 선택되었을 때의 동작 정의
     override var isSelected: Bool {
         didSet {
             UIView.transition(with: self.contentView, duration: 0.2, options: .transitionCrossDissolve) {
@@ -39,8 +41,10 @@ final class LargeChipCell: UICollectionViewCell {
     }
 }
 
-extension LargeChipCell {
+// MARK: - SetUp
+private extension LargeChipCell {
     
+    /// 초기 설정
     func setUp() {
         self.contentView.layer.cornerRadius = contentView.frame.height / 2
         self.contentView.layer.borderWidth = self.isSelected ? 0 : 1
@@ -49,6 +53,7 @@ extension LargeChipCell {
         self.label.textColor = self.isSelected ? .w100 : .g400
     }
     
+    /// 제약 조건 설정
     func setUpConstraints() {
         contentView.addSubview(label)
         label.snp.makeConstraints { make in
@@ -58,11 +63,19 @@ extension LargeChipCell {
             make.bottom.equalToSuperview().inset(9)
         }
     }
+}
+
+extension LargeChipCell {
     
+    /// 셀을 구성하는 메서드
+    /// - Parameter title: 라벨에 표시할 문자열
     func configure(title: String?) {
         label.text = title
     }
     
+    /// 셀 크기 리턴 메서드
+    /// - Parameter title: 라벨에 표시할 문자열
+    /// - Returns: 셀 크기
     func adjustCellSize(title: String) -> CGSize {
         let targetSize = CGSize(width: UIView.layoutFittingCompressedSize.width, height: UIView.layoutFittingCompressedSize.height)
         return self.contentView.systemLayoutSizeFitting(

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep1View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep1View.swift
@@ -26,6 +26,7 @@ final class SignUpStep1View: UIStackView {
         view.spacing = 16
         return view
     }()
+    private let bottomSpacingView = UIView()
     
     // MARK: - Properties
     private let disposeBag = DisposeBag()
@@ -68,6 +69,7 @@ private extension SignUpStep1View {
         self.addArrangedSubview(checkBox)
         self.addArrangedSubview(middleSpacingView)
         self.addArrangedSubview(termsStackView)
+        self.addArrangedSubview(bottomSpacingView)
     }
     
     /// 바인딩 설정

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep3View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep3View.swift
@@ -1,0 +1,154 @@
+//
+//  SignUpStep3View.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/27/24.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class SignUpStep3View: UIStackView {
+    
+    private let topSpacingView = UIView()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "관심이 있는 카테고리를 선택해주세요"
+        label.font = .KorFont(style: .bold, size: 16)
+        label.textColor = .g1000
+        return label
+    }()
+    
+    private let subLabel: UILabel = {
+        let label = UILabel()
+        label.text = "최대 5개까지 선택할 수 있어요."
+        label.font = .KorFont(style: .regular, size: 12)
+        label.textColor = .g1000
+        return label
+    }()
+    
+    private let middleSpacingView = UIView()
+    
+    private let categoryCollectionView: UICollectionView = {
+        let layout = TagsLayout()
+        layout.minimumLineSpacing = 16
+        layout.minimumInteritemSpacing = 12
+        layout.scrollDirection = .vertical
+        let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        view.register(LargeChipCell.self, forCellWithReuseIdentifier: LargeChipCell.identifier)
+        view.allowsMultipleSelection = true
+        
+        return view
+    }()
+    
+    private let disposeBag = DisposeBag()
+    
+    private let selectedList: BehaviorRelay<[IndexPath]> = .init(value: [])
+    
+    private let categoryList: BehaviorRelay<[String]> = .init(value: [])
+
+    init() {
+        super.init(frame: .zero)
+        setUp()
+        setUpConstraints()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension SignUpStep3View {
+    
+    func setUp() {
+        self.axis = .vertical
+        categoryCollectionView.delegate = self
+        categoryCollectionView.dataSource = self
+    }
+    
+    func setUpConstraints() {
+        topSpacingView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide._48px)
+        }
+        titleLabel.snp.makeConstraints { make in
+            make.height.equalTo(22)
+        }
+        subLabel.snp.makeConstraints { make in
+            make.height.equalTo(18)
+        }
+        middleSpacingView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide._36px)
+        }
+        self.addArrangedSubview(topSpacingView)
+        self.addArrangedSubview(titleLabel)
+        self.addArrangedSubview(subLabel)
+        self.addArrangedSubview(middleSpacingView)
+        self.addArrangedSubview(categoryCollectionView)
+    }
+    
+    func bind() {
+        categoryList
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.categoryCollectionView.reloadData()
+            }
+            .disposed(by: disposeBag)
+    }
+}
+
+extension SignUpStep3View {
+    func fetchSelectedList() -> Observable<[String]> {
+        return selectedList.map { indexPathList in
+            return indexPathList.compactMap { indexPath in
+                return self.categoryList.value[indexPath.row]
+            }
+        }
+    }
+    
+    func setCategoryList(list: [String]) {
+        categoryList.accept(list)
+    }
+}
+
+extension SignUpStep3View: UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return categoryList.value.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LargeChipCell.identifier, for: indexPath) as? LargeChipCell else {
+            return UICollectionViewCell()
+        }
+        cell.configure(title: categoryList.value[indexPath.row])
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let cell = LargeChipCell()
+        let title = categoryList.value[indexPath.row]
+        cell.configure(title: title)
+        return cell.adjustCellSize(title: title)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let limitSelectedCount = 5
+        var selectedListValue = selectedList.value
+        if selectedListValue.count >= limitSelectedCount {
+            collectionView.deselectItem(at: indexPath, animated: false)
+            ToastMSGManager.createToast(message: "최대 5개 까지 선택할 수 있어요")
+        } else {
+            selectedList.accept(selectedListValue + [indexPath])
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        var selectedListValue = selectedList.value
+        let targetIndex = selectedListValue.firstIndex(of: indexPath)!
+        selectedListValue.remove(at: targetIndex)
+        selectedList.accept(selectedListValue)
+    }
+}

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep3View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep3View.swift
@@ -13,8 +13,9 @@ import RxCocoa
 
 final class SignUpStep3View: UIStackView {
     
+    // MARK: - Components
     private let topSpacingView = UIView()
-    
+
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "관심이 있는 카테고리를 선택해주세요"
@@ -32,7 +33,7 @@ final class SignUpStep3View: UIStackView {
     }()
     
     private let middleSpacingView = UIView()
-    
+
     private let categoryCollectionView: UICollectionView = {
         let layout = TagsLayout()
         layout.minimumLineSpacing = 16
@@ -45,6 +46,7 @@ final class SignUpStep3View: UIStackView {
         return view
     }()
     
+    // MARK: - Properties
     private let disposeBag = DisposeBag()
     
     private let selectedList: BehaviorRelay<[IndexPath]> = .init(value: [])
@@ -62,14 +64,17 @@ final class SignUpStep3View: UIStackView {
     }
 }
 
+// MARK: - SetUp
 private extension SignUpStep3View {
     
+    /// 초기 설정 메서드
     func setUp() {
         self.axis = .vertical
         categoryCollectionView.delegate = self
         categoryCollectionView.dataSource = self
     }
     
+    /// 제약 조건 설정 메서드
     func setUpConstraints() {
         topSpacingView.snp.makeConstraints { make in
             make.height.equalTo(Constants.spaceGuide._48px)
@@ -90,6 +95,7 @@ private extension SignUpStep3View {
         self.addArrangedSubview(categoryCollectionView)
     }
     
+    /// 데이터 바인딩 메서드
     func bind() {
         categoryList
             .withUnretained(self)
@@ -101,6 +107,9 @@ private extension SignUpStep3View {
 }
 
 extension SignUpStep3View {
+    
+    /// 선택된 리스트를 가져오는 메서드
+    /// - Returns: 선택된 카테고리 리스트를 반환하는 옵저버블
     func fetchSelectedList() -> Observable<[String]> {
         return selectedList.map { indexPathList in
             return indexPathList.compactMap { indexPath in
@@ -109,6 +118,8 @@ extension SignUpStep3View {
         }
     }
     
+    /// 카테고리 리스트를 설정하는 메서드
+    /// - Parameter list: 카테고리 리스트
     func setCategoryList(list: [String]) {
         categoryList.accept(list)
     }
@@ -134,6 +145,7 @@ extension SignUpStep3View: UICollectionViewDelegateFlowLayout, UICollectionViewD
         return cell.adjustCellSize(title: title)
     }
     
+    /// 셀이 선택되었을 때의 동작 정의
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let limitSelectedCount = 5
         var selectedListValue = selectedList.value
@@ -145,6 +157,7 @@ extension SignUpStep3View: UICollectionViewDelegateFlowLayout, UICollectionViewD
         }
     }
     
+    /// 셀이 선택 해제되었을 때의 동작 정의
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         var selectedListValue = selectedList.value
         let targetIndex = selectedListValue.firstIndex(of: indexPath)!

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep4View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep4View.swift
@@ -1,0 +1,96 @@
+//
+//  SignUpStep4View.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 6/27/24.
+//
+
+import UIKit
+import SnapKit
+
+final class SignUpStep4View: UIStackView {
+    
+    private let topSpacingView = UIView()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "해당되시는 성별 / 나이대를 알려주세요"
+        label.font = .KorFont(style: .bold, size: 16)
+        label.textColor = .g1000
+        return label
+    }()
+    
+    private let subLabel: UILabel = {
+        let label = UILabel()
+        label.text = "가장 잘 맞는 팝업스토어를 소개해드릴게요."
+        label.font = .KorFont(style: .regular, size: 12)
+        label.textColor = .g1000
+        return label
+    }()
+    
+    private let subLabelBottomspacingView = UIView()
+    
+    private let genderLabel: UILabel = {
+        let label = UILabel()
+        label.text = "성별"
+        label.textColor = .g1000
+        label.font = .KorFont(style: .regular, size: 13)
+        return label
+    }()
+    
+    private let genderLabelBottomspacingView = UIView()
+    
+    private let segmentedControl: SegmentedControlCPNT = SegmentedControlCPNT(
+        type: .base,
+        segments: ["남성", "여성", "선택안함"],
+        selectedSegmentIndex: 2
+    )
+    
+    private let bottomSpacingView = UIView()
+    
+    init() {
+        super.init(frame: .zero)
+        setUp()
+        setUpConstraints()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - SetUp
+private extension SignUpStep4View {
+    func setUp() {
+        self.axis = .vertical
+    }
+    
+    func setUpConstraints() {
+        topSpacingView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide._36px)
+        }
+        titleLabel.snp.makeConstraints { make in
+            make.height.equalTo(22)
+        }
+        subLabel.snp.makeConstraints { make in
+            make.height.equalTo(18)
+        }
+        subLabelBottomspacingView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide._36px)
+        }
+        genderLabel.snp.makeConstraints { make in
+            make.height.equalTo(20)
+        }
+        genderLabelBottomspacingView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide._8px)
+        }
+        self.addArrangedSubview(topSpacingView)
+        self.addArrangedSubview(titleLabel)
+        self.addArrangedSubview(subLabel)
+        self.addArrangedSubview(subLabelBottomspacingView)
+        self.addArrangedSubview(genderLabel)
+        self.addArrangedSubview(genderLabelBottomspacingView)
+        self.addArrangedSubview(segmentedControl)
+        self.addArrangedSubview(bottomSpacingView)
+    }
+}


### PR DESCRIPTION
## Description
- Sign Up Step 3 View, SegmentedControlCPNT 개발 완료하여 확인 부탁드립니다.
- 관심사 목록은 하드코딩으로 주입한 상태이며 추후 네트워크를 통해 주입할 수 있도록 수정 하겠습니다.
- 유저명 부분 색인 효과도 Step 2 View 개발 완료 후 수정하겠습니다.
## Changes
- LargeChipCell 추가
- TagLayout 추가
- SignUpStep3View 추가
- SegmentedControlCPNT 추가
## Example
### SignUp Step3
https://github.com/PopPool/iOS/assets/112812473/5414b17f-7139-425c-acf0-f8592a482274
### SegmentedControlCPNT - base
https://github.com/PopPool/iOS/assets/112812473/2cc289e5-6165-4760-a72a-a53aaa8a6cc9
### SegmentedControlCPNT - radio
https://github.com/PopPool/iOS/assets/112812473/52ccc0fa-a949-402f-87e0-e4e3f96d73ac
### SegmentedControlCPNT - tab
https://github.com/PopPool/iOS/assets/112812473/276ebd2c-dfdb-4cad-887f-13f566da1514
```
### SegmentedControlCPNT - base
    private let segmentedControl: SegmentedControlCPNT = SegmentedControlCPNT(
        type: .base,
        segments: ["남성", "여성", "선택안함"],
        selectedSegmentIndex: 2
    )
### SegmentedControlCPNT - radio
    private let segmentedControl: SegmentedControlCPNT = SegmentedControlCPNT(
        type: .radio,
        segments: ["남성", "여성", "선택안함"],
        selectedSegmentIndex: 2
    )
### SegmentedControlCPNT - tab
    private let segmentedControl: SegmentedControlCPNT = SegmentedControlCPNT(
        type: .tab,
        segments: ["남성", "여성", "선택안함", "Test"],
        selectedSegmentIndex: 2
    )
// 생성: 배열의 인자 갯수에 따라 유동적으로 컴포넌트를 생성하며 type을 선택하여 생성 하시면 됩니다.
// 사용: UISegmentedControl를 상속하여 일반적인 UISegmentedControl처럼 사용하시면 됩니다.
```
