### PR TITLE
[MERGE] : ✅ SignUp Completed View

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		089D19132C3544DB000435D9 /* PickerCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089D19122C3544DB000435D9 /* PickerCPNT.swift */; };
 		089D19152C366E1A000435D9 /* Interest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089D19142C366E1A000435D9 /* Interest.swift */; };
 		089D19182C36715F000435D9 /* SignUpRepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089D19172C36715F000435D9 /* SignUpRepositoryTest.swift */; };
+		089D191A2C368C73000435D9 /* SignUpCompletedVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089D19192C368C73000435D9 /* SignUpCompletedVC.swift */; };
 		08A28CAA2C27E16F00DF7A90 /* SignUpVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CA92C27E16F00DF7A90 /* SignUpVC.swift */; };
 		08A28CAC2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CAB2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift */; };
 		08A28CB42C280F9600DF7A90 /* ProgressViewCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */; };
@@ -166,6 +167,7 @@
 		089D19122C3544DB000435D9 /* PickerCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerCPNT.swift; sourceTree = "<group>"; };
 		089D19142C366E1A000435D9 /* Interest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interest.swift; sourceTree = "<group>"; };
 		089D19172C36715F000435D9 /* SignUpRepositoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRepositoryTest.swift; sourceTree = "<group>"; };
+		089D19192C368C73000435D9 /* SignUpCompletedVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpCompletedVC.swift; sourceTree = "<group>"; };
 		08A28CA92C27E16F00DF7A90 /* SignUpVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpVC.swift; sourceTree = "<group>"; };
 		08A28CAB2C27E5FB00DF7A90 /* ProgressIndicatorCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicatorCPNT.swift; sourceTree = "<group>"; };
 		08A28CB32C280F9600DF7A90 /* ProgressViewCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewCPNT.swift; sourceTree = "<group>"; };
@@ -692,6 +694,7 @@
 				08A28CC02C2AF2C100DF7A90 /* Components */,
 				08A28CBF2C2AF2B800DF7A90 /* Views */,
 				08A28CB92C2AC44300DF7A90 /* SignUpVM.swift */,
+				089D19192C368C73000435D9 /* SignUpCompletedVC.swift */,
 				08A28CA92C27E16F00DF7A90 /* SignUpVC.swift */,
 			);
 			path = SignUp;
@@ -1010,6 +1013,7 @@
 				08C813D52C2D1F5E009239FE /* SignUpStep3View.swift in Sources */,
 				087346562C0AEBD900534FFA /* AppDIContainer.swift in Sources */,
 				08F49DF22C23230C002D5202 /* AuthRepository.swift in Sources */,
+				089D191A2C368C73000435D9 /* SignUpCompletedVC.swift in Sources */,
 				BDF4F2982C240BA6002F4F03 /* Constants.swift in Sources */,
 				089D19182C36715F000435D9 /* SignUpRepositoryTest.swift in Sources */,
 				087346112C0AAD2900534FFA /* AppDelegate.swift in Sources */,

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVC.swift
@@ -139,9 +139,11 @@ extension LoginVC {
         output.showLoginBottomSheet
             .subscribe(onNext: { [weak self] _ in
                 print("버튼이 눌렸습니다")
-                let vc = LoginBottomSheetVC()
+                let vc = SignUpCompletedVC(nickname: "바다사자 바다사자", tags: ["카테고리","카테고리"])
 //                self?.presentViewControllerModally(vc: vc)
-                self?.presentBottomSheet(viewController: vc)
+//                self?.presentBottomSheet(viewController: vc)
+//                self?.presentModalViewController(viewController: vc)
+                self?.navigationController?.pushViewController(vc, animated: true)
             })
             .disposed(by: disposeBag)
         

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpCompletedVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpCompletedVC.swift
@@ -1,0 +1,180 @@
+//
+//  SignUpCompletedVC.swift
+//  PopPool
+//
+//  Created by Porori on 7/3/24.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+
+final class SignUpCompletedVC: UIViewController {
+
+    // MARK: - Components
+
+    private let headerView = HeaderViewCPNT(title: "", style: .text("취소"))
+    private let iconImageView: UIImageView = {
+        let logoView = UIImageView()
+        logoView.image = UIImage(named: "check_fill_signUp")?.withTintColor(UIColor.blu500)
+        logoView.contentMode = .scaleAspectFit
+        return logoView
+    }()
+
+    private let notificationLabel: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+
+    private let tagNotificationLabel: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+
+    // 완료 화면 전체 프로퍼티를 담는 Stackview
+    private lazy var notificationStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.addArrangedSubview(spacer80)
+        stack.addArrangedSubview(iconImageView)
+        stack.addArrangedSubview(spacer32)
+        stack.addArrangedSubview(notificationLabel)
+        stack.addArrangedSubview(spacer16)
+        stack.addArrangedSubview(tagNotificationLabel)
+        return stack
+    }()
+
+    // MARK: - Properties
+
+    private let confirmButton = ButtonCPNT(type: .primary, title: "바로가기")
+    private let spacer80 = SpacingFactory.shared.createSpace(size: Constants.spaceGuide._80px)
+    private let spacer32 = SpacingFactory.shared.createSpace(size: Constants.spaceGuide._32px)
+    private let spacer16 = SpacingFactory.shared.createSpace(size: Constants.spaceGuide._16px)
+
+    private let userName: String?
+    private let categoryTags: [String]?
+    private let disposeBag = DisposeBag()
+
+    // MARK: - Initializer
+
+    init(nickname: String?, tags: [String]?) {
+        self.userName = nickname
+        self.categoryTags = tags
+        super.init(nibName: nil, bundle: nil)
+        setUpConstraints()
+        setNickName()
+        setCategory()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        print(self, #function)
+    }
+}
+
+extension SignUpCompletedVC {
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpConstraints()
+        bind()
+    }
+}
+
+private extension SignUpCompletedVC {
+
+    // MARK: - Methods
+
+    /// 닉네임 폰트, 스타일을 커스텀 적용하는 메서드
+    func setNickName() {
+        let greeting = "가입완료!\n"
+        let description = "님의\n피드를 확인해보세요"
+        let text = greeting + (userName ?? "홍길동") + description
+
+        // 전체 안내문과 닉네임에 각각 font와 컬러를 스타일로 적용합니다
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 1.5
+        let attributedString = NSMutableAttributedString(string: text)
+        let targetRange = (text as NSString).range(of: userName ?? "홍길동")
+        let fullRange = (text as NSString).range(of: text)
+        attributedString.addAttribute(.foregroundColor, value: UIColor.blu500.cgColor, range: targetRange)
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: fullRange)
+        attributedString.addAttribute(.font, value: UIFont.KorFont(style: .bold, size: 20)!, range: fullRange)
+
+        notificationLabel.attributedText = attributedString
+        notificationLabel.numberOfLines = 0
+        notificationLabel.textAlignment = .center
+    }
+
+    /// 카테고리에 폰트 및 스타일을 적용하는 메서드
+    func setCategory() {
+        let description = "와\n연관된 팝업스토어 정보를 안내해드릴게요"
+        let tags = categoryTags?.map { $0 } ?? []
+        let groupTags = tags.joined(separator: ", ")
+        let text = groupTags + description
+
+        // 카테고리에 각각 알맞는 font와 컬러를 스타일로 적용합니다
+        let style = NSMutableParagraphStyle()
+        style.lineHeightMultiple = 1.5
+        let attributedText = NSMutableAttributedString(string: text)
+        let range = (text as NSString).range(of: groupTags)
+        let full = (text as NSString).range(of: text)
+        tagNotificationLabel.font = .KorFont(style: .regular, size: 15)
+        attributedText.addAttribute(.foregroundColor, value: UIColor.g600.cgColor, range: full)
+        attributedText.addAttribute(.font, value: UIFont.KorFont(style: .bold, size: 15)!, range: range)
+        attributedText.addAttribute(.paragraphStyle, value: style, range: full)
+
+        tagNotificationLabel.attributedText = attributedText
+        tagNotificationLabel.numberOfLines = 0
+        tagNotificationLabel.textAlignment = .center
+    }
+
+    /// 컴포넌트별 제약을 잡습니다
+    func setUpConstraints() {
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(headerView)
+        headerView.rightBarButton.isHidden = true
+        headerView.leftBarButton.isHidden = true
+        headerView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(44)
+        }
+
+        view.addSubview(notificationStack)
+        notificationStack.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
+            make.top.equalTo(headerView.snp.bottom)
+        }
+
+        view.addSubview(confirmButton)
+        confirmButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.height.equalTo(52)
+            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide._20px)
+            make.bottom.equalToSuperview().inset(Constants.spaceGuide._48px)
+        }
+    }
+
+    /// 완료 버튼이 탭된 이후 현재 navigationController를 이후 넘어가는 loginVC로 교체됩니다
+    func dismissVC() {
+        let vc = LoginVC()
+        navigationController?.setViewControllers([vc], animated: true)
+    }
+
+    func bind() {
+        confirmButton.rx.tap
+            .withUnretained(self)
+            .bind { (owner, _) in
+                owner.dismissVC()
+            }
+            .disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
## Description
- 이제 어플에서 signUp 완료 페이지가 보일 수 있습니다.
*화면 연결은 필요한 상황입니다.
- 유저 닉네임과 카테고리 태그를 인자로 받을 수 있습니다.

## Changes
- Figma에 맞춰 signup complete 화면이 구현됐습니다.

## Example

![image](https://github.com/PopPool/iOS/assets/119504454/8fa0ba78-db91-4977-9d71-e19b983ac6bb)

initializer에서 nickname과 tag 값을 받습니다.
아래 예시와 init 코드는 참고 부탁 드립니다!

```
 init(nickname: String?, tags: [String]?) {
        self.userName = nickname
        self.categoryTags = tags
        super.init(nibName: nil, bundle: nil)
        setUpConstraints()
        setNickName()
        setCategory()
    }

// MARK: - 활용 예시
let interests = ["패션", "게임",  "iOS", "개발" ]
let vc = SignUpCompletedVC(nickname: 서준여이, tags: interests)
```
