### PR TITLE
[MERGE]: ✅ TextFieldValidation 구현

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -97,11 +97,13 @@
 		BD3C4C6F2C313D6C0087917B /* LoginBottomSheetVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3C4C6E2C313D6C0087917B /* LoginBottomSheetVM.swift */; };
 		BD57D4E82C30C63A0036E874 /* LoginBottomSheetVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD57D4E72C30C63A0036E874 /* LoginBottomSheetVC.swift */; };
 		BD6368082C0CBEFE00891A1B /* PopPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6368072C0CBEFE00891A1B /* PopPoolTests.swift */; };
+		BD7C6A052C37B75200C557D9 /* TestVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7C6A042C37B75200C557D9 /* TestVC.swift */; };
 		BD86079B2C23429D00726692 /* DatabaseTYPE.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD86079A2C23429D00726692 /* DatabaseTYPE.swift */; };
 		BD9901CD2C2877BF0024F30D /* ToastMSGCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9901CC2C2877BF0024F30D /* ToastMSGCPNT.swift */; };
 		BDA0B1342C2DD102007BDCA4 /* Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA0B1332C2DD102007BDCA4 /* Factory.swift */; };
 		BDA0B1372C2E622B007BDCA4 /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA0B1362C2E622B007BDCA4 /* ModalViewController.swift */; };
 		BDB682552C1C316000560E7B /* LocalDBRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB682542C1C316000560E7B /* LocalDBRepository.swift */; };
+		BDBB4D1B2C3999AA008E2857 /* BaseTextFieldCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB4D1A2C3999AA008E2857 /* BaseTextFieldCPNT.swift */; };
 		BDC622B12C225817009411AE /* DatabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B02C225817009411AE /* DatabaseError.swift */; };
 		BDC622B52C2294D4009411AE /* LocalSaveUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B42C2294D4009411AE /* LocalSaveUseCaseImpl.swift */; };
 		BDC622B72C229517009411AE /* UserdefaultRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B62C229517009411AE /* UserdefaultRepositoryImpl.swift */; };
@@ -111,6 +113,7 @@
 		BDF3B2AA2C0BE23D00B079C5 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF3B2A92C0BE23D00B079C5 /* Requestable.swift */; };
 		BDF3B2AE2C0BE69700B079C5 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF3B2AD2C0BE69700B079C5 /* Provider.swift */; };
 		BDF3B2C12C0C318E00B079C5 /* Responsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF3B2C02C0C318E00B079C5 /* Responsable.swift */; };
+		BDF3BF952C3A837000222692 /* TextFieldCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF3BF942C3A837000222692 /* TextFieldCPNT.swift */; };
 		BDF4F2962C240B95002F4F03 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4F2952C240B95002F4F03 /* UIColor+.swift */; };
 		BDF4F2982C240BA6002F4F03 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4F2972C240BA6002F4F03 /* Constants.swift */; };
 		BDF4F29C2C2422DF002F4F03 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF4F29B2C2422DF002F4F03 /* UIFont+.swift */; };
@@ -222,11 +225,13 @@
 		BD3C4C6E2C313D6C0087917B /* LoginBottomSheetVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginBottomSheetVM.swift; sourceTree = "<group>"; };
 		BD57D4E72C30C63A0036E874 /* LoginBottomSheetVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginBottomSheetVC.swift; sourceTree = "<group>"; };
 		BD6368072C0CBEFE00891A1B /* PopPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolTests.swift; sourceTree = "<group>"; };
+		BD7C6A042C37B75200C557D9 /* TestVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestVC.swift; sourceTree = "<group>"; };
 		BD86079A2C23429D00726692 /* DatabaseTYPE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseTYPE.swift; sourceTree = "<group>"; };
 		BD9901CC2C2877BF0024F30D /* ToastMSGCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMSGCPNT.swift; sourceTree = "<group>"; };
 		BDA0B1332C2DD102007BDCA4 /* Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Factory.swift; sourceTree = "<group>"; };
 		BDA0B1362C2E622B007BDCA4 /* ModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
 		BDB682542C1C316000560E7B /* LocalDBRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBRepository.swift; sourceTree = "<group>"; };
+		BDBB4D1A2C3999AA008E2857 /* BaseTextFieldCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTextFieldCPNT.swift; sourceTree = "<group>"; };
 		BDC622B02C225817009411AE /* DatabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseError.swift; sourceTree = "<group>"; };
 		BDC622B42C2294D4009411AE /* LocalSaveUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalSaveUseCaseImpl.swift; sourceTree = "<group>"; };
 		BDC622B62C229517009411AE /* UserdefaultRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserdefaultRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -236,6 +241,7 @@
 		BDF3B2A92C0BE23D00B079C5 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		BDF3B2AD2C0BE69700B079C5 /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		BDF3B2C02C0C318E00B079C5 /* Responsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Responsable.swift; sourceTree = "<group>"; };
+		BDF3BF942C3A837000222692 /* TextFieldCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldCPNT.swift; sourceTree = "<group>"; };
 		BDF4F2952C240B95002F4F03 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		BDF4F2972C240BA6002F4F03 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		BDF4F29B2C2422DF002F4F03 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
@@ -648,6 +654,8 @@
 				BD353B462C2C13460004659D /* HeaderViewCPNT.swift */,
 				08C813DF2C2D82EF009239FE /* SegmentedControlCPNT.swift */,
 				089D18FF2C30307A000435D9 /* ValidationTextFieldCPNT.swift */,
+				BDBB4D1A2C3999AA008E2857 /* BaseTextFieldCPNT.swift */,
+				BDF3BF942C3A837000222692 /* TextFieldCPNT.swift */,
 				089D19122C3544DB000435D9 /* PickerCPNT.swift */,
 			);
 			path = Components;
@@ -684,6 +692,7 @@
 			children = (
 				BD3C4C752C31AF6A0087917B /* LoginBottomSheet */,
 				08F49E082C240335002D5202 /* LoginVC.swift */,
+				BD7C6A042C37B75200C557D9 /* TestVC.swift */,
 				BD353B4A2C2D3D7D0004659D /* LoginVM.swift */,
 			);
 			path = Login;
@@ -988,6 +997,7 @@
 				08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */,
 				08C813F12C2EF60B009239FE /* CheckNickNameRequestDTO.swift in Sources */,
 				BD86079B2C23429D00726692 /* DatabaseTYPE.swift in Sources */,
+				BDBB4D1B2C3999AA008E2857 /* BaseTextFieldCPNT.swift in Sources */,
 				085105822C102F8000ED7DBB /* KakaoAuthServiceImpl.swift in Sources */,
 				087346152C0AAD2900534FFA /* ViewController.swift in Sources */,
 				08A28CC62C2BE1EA00DF7A90 /* Inputable.swift in Sources */,
@@ -1026,6 +1036,7 @@
 				0873464E2C0AB1CA00534FFA /* ViewControllerViewModel.swift in Sources */,
 				BDC622B72C229517009411AE /* UserdefaultRepositoryImpl.swift in Sources */,
 				BDFA49242C342B3600D3C1FB /* UIView+.swift in Sources */,
+				BDF3BF952C3A837000222692 /* TextFieldCPNT.swift in Sources */,
 				BD353B4B2C2D3D7D0004659D /* LoginVM.swift in Sources */,
 				087346132C0AAD2900534FFA /* SceneDelegate.swift in Sources */,
 				08F49DE82C231C40002D5202 /* SocialTYPE.swift in Sources */,
@@ -1040,6 +1051,7 @@
 				08B965602C1441C100BF95AA /* AppleAuthServiceImpl.swift in Sources */,
 				08A28CB42C280F9600DF7A90 /* ProgressViewCPNT.swift in Sources */,
 				08F49E092C240335002D5202 /* LoginVC.swift in Sources */,
+				BD7C6A052C37B75200C557D9 /* TestVC.swift in Sources */,
 				BDF3B2AE2C0BE69700B079C5 /* Provider.swift in Sources */,
 				BD3C4C6D2C30C8AE0087917B /* HeaderViewCPNT.swift in Sources */,
 				BD353B472C2C13460004659D /* HeaderViewCPNT.swift in Sources */,

--- a/PopPool/PopPool/Presentation/Components/BaseTextFieldCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/BaseTextFieldCPNT.swift
@@ -1,0 +1,134 @@
+//
+//  BaseTextFieldCPNT.swift
+//  PopPool
+//
+//  Created by Porori on 7/7/24.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+
+class BaseTextFieldCPNT: UIStackView {
+    
+    // MARK: - Components
+    
+    /// 전체 뷰
+    let containerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.w100
+        view.layer.borderColor = UIColor.g100.cgColor
+        view.layer.borderWidth = 1.2
+        view.layer.cornerRadius = 4
+        view.clipsToBounds = true
+        return view
+    }()
+    
+    /// textfield + 버튼 stack
+    let textFieldStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        return view
+    }()
+    
+    /// textfield 자체
+    let textField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "기본 값"
+        textField.font = .KorFont(style: .medium, size: 14)
+        return textField
+    }()
+    
+    /// 텍스트 필드에서의 삭제 버튼
+    let cancelButton: UIButton = {
+        let button = UIButton()
+        let backgroudImage = UIImage(named: "cancel_signUp")
+        button.setBackgroundImage(backgroudImage, for: .normal)
+        button.setBackgroundImage(backgroudImage, for: .highlighted)
+        return button
+    }()
+    
+    /// valdiationLabel + 0/0자
+    let validationStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.directionalLayoutMargins = .init(top: 0, leading: 4, bottom: 0, trailing: 4)
+        view.isLayoutMarginsRelativeArrangement = true
+        return view
+    }()
+    
+    /// 문제가 있을 때 하단에 등장하는 validationLabel
+    let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .regular, size: 12)
+        label.text = "기본 값"
+        return label
+    }()
+    
+    /// 0/0자
+    let textCountLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .right
+        label.font = .KorFont(style: .regular, size: 12)
+        label.textColor = .g500
+        label.text = "기본 값"
+        return label
+    }()
+    
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Initializer
+    
+    // init 단계에서 인자를 받는다?
+    init() {
+        super.init(frame: .zero)
+        setAutoLayout()
+        
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension BaseTextFieldCPNT {
+    
+    // MARK: - Methods
+    
+    private func setAutoLayout() {
+        self.spacing = 6
+        self.axis = .vertical
+        
+        setUpContainerView()
+        setUpTextfield()
+        setUpDescriptionLabels()
+    }
+    
+    private func setUpContainerView() {
+        addArrangedSubview(containerView)
+        containerView.snp.makeConstraints { make in
+            make.height.equalTo(52)
+        }
+    }
+    
+    private func setUpTextfield() {
+        containerView.addSubview(textFieldStackView)
+        textFieldStackView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.top.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview().inset(15)
+        }
+        
+        textFieldStackView.addArrangedSubview(textField)
+        textFieldStackView.addArrangedSubview(cancelButton)
+        cancelButton.snp.makeConstraints { make in
+            make.width.equalTo(21)
+        }
+    }
+    
+    private func setUpDescriptionLabels() {
+        validationStackView.addArrangedSubview(descriptionLabel)
+        validationStackView.addArrangedSubview(textCountLabel)
+        self.addArrangedSubview(validationStackView)
+    }
+}

--- a/PopPool/PopPool/Presentation/Components/TextFieldCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/TextFieldCPNT.swift
@@ -1,0 +1,179 @@
+//
+//  TextFieldCPNT.swift
+//  PopPool
+//
+//  Created by Porori on 7/7/24.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxRelay
+import RxCocoa
+
+class TextFieldCPNT: BaseTextFieldCPNT {
+    
+    // 전반적인 데이터 변경에 대한 색상 담당
+    enum ValidationState {
+        case isValid
+        case isOver
+        case none
+        
+        var descriptionColor: UIColor {
+            switch self {
+            case .isOver: return UIColor.red
+            case .isValid, .none: return UIColor.black
+            }
+        }
+    }
+    
+    // 전반적인 데이터 변경에 대한 실질적인 값 변경
+    enum ContentType {
+        case nickname
+        case social
+        case email(SocialTYPE)
+
+        var placeholder: String {
+            switch self {
+            case .email:
+                return "이메일 주소를 입력해주세요"
+            case .nickname:
+                return "별명을 입력해주세요"
+            case .social:
+                return "인스타그램 ID를 입력해주세요"
+            }
+        }
+        
+        var description: String {
+            switch self {
+            case .email(let email):
+                if email.rawValue == "apple" {
+                    return "애플에 연동된 이메일 주소입니다"
+                } else {
+                    return "카카오에 연동된 이메일 주소입니다"
+                }
+            case .nickname:
+                return "사용중인 별명이에요"
+            case .social:
+                return "인스타그램 코멘트와 마이페이지에 ID가 노출됩니다"
+            }
+        }
+    }
+    
+    private lazy var checkValidationStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.addArrangedSubview(checkValidationButton)
+        stack.addArrangedSubview(checkValidationLine)
+        return stack
+    }()
+    
+    private let checkValidationButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("중복체크", for: .normal)
+        button.titleLabel?.font = .KorFont(style: .regular, size: 13)
+        button.setTitleColor(.g1000, for: .normal)
+        return button
+    }()
+    
+    private let checkValidationLine: UIView = {
+        let line = UIView()
+        line.layer.borderColor = UIColor.g300.cgColor
+        line.layer.borderWidth = 1
+        return line
+    }()
+    
+    private let disposeBag = DisposeBag()
+    let validationType: BehaviorRelay<ValidationState> = .init(value: .none)
+    
+    init(type: ContentType, content: String) {
+        super.init()
+        setUp()
+        bind()
+        
+        switch type {
+        case .email:
+            containerView.backgroundColor = UIColor.g200
+            textField.textColor = UIColor.g300
+            textField.isUserInteractionEnabled = false
+            cancelButton.isHidden = true
+            textCountLabel.isHidden = true
+            checkValidationStack.isHidden = true
+            
+            descriptionLabel.text = type.description
+            textField.placeholder = type.placeholder
+            textField.text = content
+            
+        case .nickname:
+            textField.placeholder = type.placeholder
+            descriptionLabel.text = type.description
+            
+        case .social:
+            textCountLabel.isHidden = true
+            textField.placeholder = type.placeholder
+            descriptionLabel.text = type.description
+        }
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUp() {
+        textFieldStackView.addArrangedSubview(checkValidationStack)
+        checkValidationLine.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(1)
+        }
+    }
+    
+    private func bind() {
+        textField.rx.text.orEmpty
+            .withUnretained(self)
+            .subscribe { (owner, value) in
+                owner.updateDescription(text: value)
+            }
+            .disposed(by: disposeBag)
+        
+        cancelButton.rx.tap
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.textField.text = ""
+                owner.descriptionLabel.text = "변경됨"
+            }
+            .disposed(by: disposeBag)
+        
+        validationType
+            .withUnretained(self)
+            .subscribe { (owner, state) in
+                if state == .isOver {
+                    self.changeView(value: state)
+                } else {
+                    self.changeView(state: state)
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    private func isTextCountValid(content: String) {
+        let count = content.count
+        
+        if count < 0 {
+            validationType.accept(.none)
+        } else if count <= 10 {
+            validationType.accept(.isValid)
+        } else {
+            validationType.accept(.isOver)
+        }
+    }
+    
+    private func updateDescription(text: String) {
+        let count = text.count
+        self.descriptionLabel.text = text
+        self.textCountLabel.text = "\(count)/10자"
+    }
+    
+    func changeView(value: ContentType) {
+        self.descriptionLabel.text = value.description
+    }
+}

--- a/PopPool/PopPool/Presentation/Components/ValidationTextField.swift
+++ b/PopPool/PopPool/Presentation/Components/ValidationTextField.swift
@@ -15,6 +15,8 @@ final class ValidationTextField: BaseTextFieldCPNT {
         case nickName
     }
     
+    /// 입력 상태를 정리하기 위한 enum입니다
+    /// 텍스트필드별 추가되는 상태를 적용해주세요
     enum ValidationState {
         case none
         case requestKorOrEn
@@ -48,6 +50,7 @@ final class ValidationTextField: BaseTextFieldCPNT {
             }
         }
         
+        /// 텍스트필드를 감싸는 view의 컬러값
         var borderColor: UIColor {
             switch state {
             case .overText, .duplicateNickname, .shortText, .requestKorOrEn:
@@ -59,6 +62,7 @@ final class ValidationTextField: BaseTextFieldCPNT {
             }
         }
         
+        /// 텍스트필드 하단의 획의 count 컬러값
         var countLabelColor: UIColor {
             switch state {
             case .overText, .shortText:
@@ -68,6 +72,7 @@ final class ValidationTextField: BaseTextFieldCPNT {
             }
         }
         
+        /// 텍스트필드 하단의 각 설명의 컬러값
         var descriptionColor: UIColor {
             switch state {
             case .overText, .duplicateNickname, .shortText, .requestKorOrEn:
@@ -79,18 +84,18 @@ final class ValidationTextField: BaseTextFieldCPNT {
             }
         }
         
+        /// state별로 x 버튼의 출력 여부
         var isClearButtonHidden: Bool {
             switch state {
             case .none, .requestKorOrEn, .requestButtonTap, .valid:
-                // 안 보이는 시점
                 return true
                 
             case .shortText, .duplicateNickname, .overText:
-                // 보이는 시점
                 return false
             }
         }
         
+        /// state별로 '중복체크' 버튼의 출력 여부
         var isDuplicateCheckButtonHidden: Bool {
             switch state {
             case .none, .shortText, .overText, .duplicateNickname:
@@ -130,6 +135,8 @@ final class ValidationTextField: BaseTextFieldCPNT {
     
     // MARK: - Properties
     
+    /// 상태 값의 변화를 감지하는 옵저버
+    /// bind()에서 텍스트필드의 입력 값에 따라 변경된 값을 적용하는 것을 돕습니다
     private let stateObserver:PublishSubject<ValidationState> = .init()
     private let type: ValidationType
     
@@ -186,6 +193,9 @@ final class ValidationTextField: BaseTextFieldCPNT {
             .disposed(by: disposeBag)
     }
     
+    /// 텍스트필드 입력 값에 반응하는 메서드
+    /// - Parameter text: 텍스트 필드에 입력된 String 타입을 받습니다
+    /// - Returns: ValidationState로 상태 값을 반환합니다
     private func fetchValidationState(text: String) -> ValidationState {
         if text.count == 0 {
             return .none
@@ -195,6 +205,7 @@ final class ValidationTextField: BaseTextFieldCPNT {
             return .overText
         }
         
+        // 국문, 영문을 확인하는 Regx 코드
         let regex = "^[가-힣A-Za-z0-9\\s]*$"
         let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
         if !predicate.evaluate(with: text) {
@@ -203,6 +214,9 @@ final class ValidationTextField: BaseTextFieldCPNT {
         return .valid
     }
     
+    /// ValidationOutput 상태 값에 반응하는 메서드
+    /// 상태에 맞는 컬러 값을 바꾸고 특정 버튼 등을 숨김 처리합니다.
+    /// - Parameter output: 상태 값 타입인 ValidationOutPut을 받습니다
     private func setUpViewFrom(output: ValidationOutPut) {
         
         // 색상 적용

--- a/PopPool/PopPool/Presentation/Components/ValidationTextFieldCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ValidationTextFieldCPNT.swift
@@ -12,6 +12,38 @@ import RxSwift
 
 final class ValidationTextFieldCPNT: UIStackView {
     
+    enum ContentType {
+        case nickname
+        case social
+        case email(SocialTYPE)
+
+        var placeholder: String {
+            switch self {
+            case .email:
+                return "이메일 주소를 입력해주세요"
+            case .nickname:
+                return "별명을 입력해주세요"
+            case .social:
+                return "인스타그램 ID를 입력해주세요"
+            }
+        }
+        
+        var description: String {
+            switch self {
+            case .email(let email):
+                if email.rawValue == "apple" {
+                    return "애플에 연동된 이메일 주소입니다"
+                } else {
+                    return "카카오에 연동된 이메일 주소입니다"
+                }
+            case .nickname:
+                return "사용중인 별명이에요"
+            case .social:
+                return "인스타그램 코멘트와 마이페이지에 ID가 노출됩니다"
+            }
+        }
+    }
+    
     enum NickNameValidationState {
         case available
         case none
@@ -167,11 +199,39 @@ final class ValidationTextFieldCPNT: UIStackView {
     let nickNameObserver: PublishSubject<String?> = .init()
     private let disposeBag = DisposeBag()
     
-    init(placeholder: String) {
+    init(type: ContentType) {
         super.init(frame: .zero)
-        setUp(placeholder: placeholder)
-        setUpConstraints()
-        bind()
+        switch type {
+        case .nickname:
+            setUp(type: type)
+            setUpConstraints()
+            bind()
+            
+        case .social:
+            setUp(type: type)
+            setUpConstraints()
+            bind()
+            
+            
+            
+        case .email:
+            setUp(type: type)
+            setUpConstraints()
+            bind()
+            
+            textFieldTrailingView.backgroundColor = UIColor.g200
+            textField.isUserInteractionEnabled = false
+            cancelButton.isHidden = true
+            textCountLabel.isHidden = true
+            duplicationCheckStackView.isHidden = true
+            
+            if let text = textField.text, !text.isEmpty {
+                validationLabel.text = type.description
+            } else {
+                validationLabel.text = type.description
+                textField.placeholder = type.placeholder
+            }
+        }
     }
     
     required init(coder: NSCoder) {
@@ -183,7 +243,7 @@ private extension ValidationTextFieldCPNT {
     
     /// 초기 설정을 수행하는 메서드
     /// - Parameter placeholder: 텍스트 필드의 플레이스홀더
-    func setUp(placeholder: String) {
+    func setUp(type: ContentType) {
         self.axis = .vertical
         self.spacing = 6
         textFieldTrailingView.layer.borderWidth = 1.2
@@ -191,7 +251,7 @@ private extension ValidationTextFieldCPNT {
         textFieldTrailingView.layer.cornerRadius = 4
         
         textField.attributedPlaceholder = NSAttributedString(
-            string: placeholder,
+            string: type.placeholder,
             attributes: [
                 .foregroundColor: UIColor.g200,
                 .font: UIFont.KorFont(style: .medium, size: 14)!

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVC.swift
@@ -139,10 +139,8 @@ extension LoginVC {
         output.showLoginBottomSheet
             .subscribe(onNext: { [weak self] _ in
                 print("버튼이 눌렸습니다")
-                let vc = SignUpCompletedVC(nickname: "바다사자 바다사자", tags: ["카테고리","카테고리"])
-//                self?.presentViewControllerModally(vc: vc)
-//                self?.presentBottomSheet(viewController: vc)
-//                self?.presentModalViewController(viewController: vc)
+//                let vc = SignUpCompletedVC(nickname: "바다사자 바다사자", tags: ["카테고리","카테고리"])
+                let vc = TestVC()
                 self?.navigationController?.pushViewController(vc, animated: true)
             })
             .disposed(by: disposeBag)

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/TestVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/TestVC.swift
@@ -1,0 +1,43 @@
+//
+//  TestVC.swift
+//  PopPool
+//
+//  Created by Porori on 7/5/24.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+import RxSwift
+
+class TestVC: UIViewController {
+    
+//    let test = ValidationTextFieldCPNT(type: .social)
+//    let test = ValidationTextFieldCPNT(type: .email)
+//    let test = BaseTextFieldCPNT()
+//    let test = TextFieldCPNT(content: "이런 내용", placeholder: "이런 플레이스 홀더", label: "New description")
+//    let test = TextFieldCPNT(type: .email, content: "어떤 내용")
+    let test = TextFieldCPNT(type: .social, content: "hmmm")
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setConstraint()
+    }
+    
+    private func setConstraint() {
+        view.addSubview(test)
+//        view.addSubview(testTF2)
+//        
+        test.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+//        
+//        testTF2.snp.makeConstraints { make in
+//            make.centerX.equalToSuperview()
+//            make.top.equalTo(view.snp.top).inset(100)
+//            make.leading.trailing.equalToSuperview()
+//        }
+    }
+}

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
@@ -167,7 +167,7 @@ private extension SignUpVC {
     func bind() {
         
         // 중복확인 버튼 클릭시 키보드 다운 처리
-        step2_ContentView.validationTextField.duplicationCheckButton.rx.tap
+        step2_ContentView.validationTextField.checkValidationButton.rx.tap
             .withUnretained(self)
             .subscribe { (owner, _) in
                 owner.view.endEditing(true)
@@ -182,8 +182,8 @@ private extension SignUpVC {
             event_step1_didChangeTerms: step1_ContentView.terms,
             tap_step1_termsButton: step1_ContentView.didTapTerms,
             tap_step2_primaryButton: step2_primaryButton.rx.tap,
-            tap_step2_nickNameCheckButton: step2_ContentView.validationTextField.duplicationCheckButton.rx.tap,
-            event_step2_availableNickName: step2_ContentView.validationTextField.nickNameObserver,
+            tap_step2_nickNameCheckButton: step2_ContentView.validationTextField.checkValidationButton.rx.tap,
+            event_step2_availableNickName: step2_ContentView.validationTextField.nameObserver,
             tap_step3_primaryButton: step3_primaryButton.rx.tap,
             tap_step3_secondaryButton: step3_secondaryButton.rx.tap,
             event_step3_didChangeInterestList: step3_ContentView.fetchSelectedList(),
@@ -246,7 +246,9 @@ private extension SignUpVC {
             .withUnretained(self)
             .debounce(.microseconds(200), scheduler: MainScheduler.instance)
             .subscribe { (owner, isDuplicate) in
-                owner.step2_ContentView.validationTextField.validationState.accept(isDuplicate ? .duplicateNickname : .available)
+                // 텍스트 필드 컴포넌트의 observer를 통해 다음 값을 넘김
+                // 중복일 경우 duplicate - 아닐 경우 통과
+                owner.step2_ContentView.validationTextField.stateObserver.onNext(isDuplicate ? .duplicateNickname : .valid)
             }
             .disposed(by: disposeBag)
         

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep2View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep2View.swift
@@ -11,7 +11,7 @@ import SnapKit
 final class SignUpStep2View: UIStackView {
     // MARK: - Components
     private let topSpacingView = UIView()
-    let validationTextField = ValidationTextFieldCPNT(type: .nickname)
+    let validationTextField = ValidationTextField(placeHolder: "별명을 적어주세요", limitTextCount: 10)
     private let bottomSpacingView = UIView()
     
     // MARK: - init

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep2View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep2View.swift
@@ -11,7 +11,7 @@ import SnapKit
 final class SignUpStep2View: UIStackView {
     // MARK: - Components
     private let topSpacingView = UIView()
-    let validationTextField = ValidationTextFieldCPNT(placeholder: "별명을 입력해주세요")
+    let validationTextField = ValidationTextFieldCPNT(type: .nickname)
     private let bottomSpacingView = UIView()
     
     // MARK: - init


### PR DESCRIPTION
## Description
- 초기 구현된 textfield validation에 추가 적용하였습니다.
- 닉네임 관련 텍스트 필드는 ValidationTextField, 이외 기본 텍스트 필드는 BaseTextFieldCPNT가 적용되어야 합니다.

## Issues
- SignUpVC에서 view2의 컴포넌트를 바꾼 결과, 중복 체크 버튼를 탭하지 않아도 입력된 값으로 다음 화면을 넘어갈 수 있는 문제가 있습니다.
지금까지 이해하기로는 BehaviorRelay가 아닌 PublishSubject로 변경된 값을 담고 있기 때문에 제대로 값이 넘어가지 않았거나
버튼을 활성화 / 비활성화 하는 메서드가 상태 값이 아닌 텍스트 값이 있는지 여부만 확인하고 버튼을 활성화하는 것으로 보이는데요..!

다소 이해가 안되는 부분이 있어 관련해서 이슈를 남겨봅니다!

## Example
https://github.com/PopPool/iOS/assets/119504454/e79fa499-43e5-4e63-99eb-d1da29f27ff8

