### PR TITLE
[MERGE]: ValidationTF status별 반응 코드 추가

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -91,10 +91,11 @@
 		08F49DFD2C2400FC002D5202 /* ButtonCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DFC2C2400FC002D5202 /* ButtonCPNT.swift */; };
 		08F49E092C240335002D5202 /* LoginVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49E082C240335002D5202 /* LoginVC.swift */; };
 		08F49E0B2C240345002D5202 /* _@_@_.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49E0A2C240345002D5202 /* _@_@_.swift */; };
+		BD1D886A2C3D952500380F80 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1D88692C3D952500380F80 /* Secrets.swift */; };
+		BD1D886C2C3D958D00380F80 /* BaseTextFieldCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1D886B2C3D958D00380F80 /* BaseTextFieldCPNT.swift */; };
 		BD27D0902C35A9020092FC36 /* LocalFetchUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD27D08F2C35A9020092FC36 /* LocalFetchUseCaseImpl.swift */; };
 		BD27D0922C35A9130092FC36 /* LocalDeleteUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD27D0912C35A9130092FC36 /* LocalDeleteUseCaseImpl.swift */; };
 		BD2E90F52C1B17C200BB0313 /* KeyChainRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E90F42C1B17C200BB0313 /* KeyChainRepositoryImpl.swift */; };
-		BD353B452C2BE42C0004659D /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD353B442C2BE42C0004659D /* Secrets.swift */; };
 		BD353B472C2C13460004659D /* HeaderViewCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD353B462C2C13460004659D /* HeaderViewCPNT.swift */; };
 		BD353B4B2C2D3D7D0004659D /* LoginVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD353B4A2C2D3D7D0004659D /* LoginVM.swift */; };
 		BD3C4C6A2C30C8880087917B /* InfoBoxViewCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD3C4C682C30C8880087917B /* InfoBoxViewCPNT.swift */; };
@@ -222,10 +223,11 @@
 		08F49DFC2C2400FC002D5202 /* ButtonCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonCPNT.swift; sourceTree = "<group>"; };
 		08F49E082C240335002D5202 /* LoginVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVC.swift; sourceTree = "<group>"; };
 		08F49E0A2C240345002D5202 /* _@_@_.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_@_@_.swift"; sourceTree = "<group>"; };
+		BD1D88692C3D952500380F80 /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
+		BD1D886B2C3D958D00380F80 /* BaseTextFieldCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTextFieldCPNT.swift; sourceTree = "<group>"; };
 		BD27D08F2C35A9020092FC36 /* LocalFetchUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFetchUseCaseImpl.swift; sourceTree = "<group>"; };
 		BD27D0912C35A9130092FC36 /* LocalDeleteUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDeleteUseCaseImpl.swift; sourceTree = "<group>"; };
 		BD2E90F42C1B17C200BB0313 /* KeyChainRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainRepositoryImpl.swift; sourceTree = "<group>"; };
-		BD353B442C2BE42C0004659D /* Secrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		BD353B462C2C13460004659D /* HeaderViewCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderViewCPNT.swift; sourceTree = "<group>"; };
 		BD353B4A2C2D3D7D0004659D /* LoginVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVM.swift; sourceTree = "<group>"; };
 		BD3C4C682C30C8880087917B /* InfoBoxViewCPNT.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoBoxViewCPNT.swift; sourceTree = "<group>"; };
@@ -425,7 +427,7 @@
 				BDF4F29D2C242FE8002F4F03 /* Font */,
 				087346192C0AAD2B00534FFA /* Assets.xcassets */,
 				0873461B2C0AAD2B00534FFA /* LaunchScreen.storyboard */,
-				BD353B442C2BE42C0004659D /* Secrets.swift */,
+				BD1D88692C3D952500380F80 /* Secrets.swift */,
 				0873461E2C0AAD2B00534FFA /* Info.plist */,
 			);
 			path = Resource;
@@ -727,6 +729,7 @@
 				08A28CB52C2A97E300DF7A90 /* ContentTitleCPNT.swift */,
 				BD353B462C2C13460004659D /* HeaderViewCPNT.swift */,
 				08C813DF2C2D82EF009239FE /* SegmentedControlCPNT.swift */,
+				BD1D886B2C3D958D00380F80 /* BaseTextFieldCPNT.swift */,
 				089D18FF2C30307A000435D9 /* ValidationTextFieldCPNT.swift */,
 				089D19122C3544DB000435D9 /* PickerCPNT.swift */,
 				089D19282C3BD318000435D9 /* ProfileImageViewCPNT.swift */,
@@ -1096,6 +1099,7 @@
 				08B183AE2C3D2601006C34BB /* TokenInterceptor.swift in Sources */,
 				BDC622B12C225817009411AE /* DatabaseError.swift in Sources */,
 				089D19102C352E1E000435D9 /* SignUpSelectAgeModalVC.swift in Sources */,
+				BD1D886A2C3D952500380F80 /* Secrets.swift in Sources */,
 				08C813D92C2D294D009239FE /* UICollectionViewCell+.swift in Sources */,
 				08A28CB62C2A97E300DF7A90 /* ContentTitleCPNT.swift in Sources */,
 				08C813FD2C2F2C14009239FE /* SignUpRepository.swift in Sources */,
@@ -1117,7 +1121,6 @@
 				08F49DE82C231C40002D5202 /* SocialTYPE.swift in Sources */,
 				087A68B12C1ECEBC00CF3631 /* LocalDBUseCase.swift in Sources */,
 				08C813FB2C2F2809009239FE /* SignUpRequestDTO.swift in Sources */,
-				BD353B452C2BE42C0004659D /* Secrets.swift in Sources */,
 				08B9658F2C16004D00BF95AA /* PopPoolAPIEndPoint.swift in Sources */,
 				BD9901CD2C2877BF0024F30D /* ToastMSGCPNT.swift in Sources */,
 				BDD3351A2C0B3AF1002C2295 /* NetworkError.swift in Sources */,
@@ -1142,6 +1145,7 @@
 				08A28CC22C2AF2DD00DF7A90 /* SignUpStep1View.swift in Sources */,
 				BDA0B1342C2DD102007BDCA4 /* Factory.swift in Sources */,
 				08B9658A2C15FEBF00BF95AA /* FetchSocialCredentialUseCaseImpl.swift in Sources */,
+				BD1D886C2C3D958D00380F80 /* BaseTextFieldCPNT.swift in Sources */,
 				08F49DF02C2321B8002D5202 /* AuthRepositoryImpl.swift in Sources */,
 				BDF4F2962C240B95002F4F03 /* UIColor+.swift in Sources */,
 				BDD335202C0B6ACA002C2295 /* EndPoint.swift in Sources */,

--- a/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk.git",
       "state" : {
-        "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940",
-        "version" : "2.22.3"
+        "revision" : "08089eeffc9b442da1c7343a70bf66c6de1a72c9",
+        "version" : "2.22.4"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
       "state" : {
-        "revision" : "37ac7e289fea5f62b3b1f62d06290a18a202a5b0",
-        "version" : "2.22.3"
+        "revision" : "bdcb118183ef59a75753a69ac5d3cc93def0baa3",
+        "version" : "2.22.4"
       }
     },
     {

--- a/PopPool/PopPool/Presentation/Components/BaseTextFieldCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/BaseTextFieldCPNT.swift
@@ -1,0 +1,159 @@
+//
+//  BaseTextFieldCPNT.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 7/8/24.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+class BaseTextFieldCPNT: UIStackView {
+    
+    let textFieldBackGroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemBackground
+        view.layer.borderColor = UIColor.g100.cgColor
+        view.layer.borderWidth = 1.2
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    
+    let textFieldStackView: UIStackView = {
+        let view = UIStackView()
+        return view
+    }()
+    
+    let textField: UITextField = {
+        let view = UITextField()
+        view.font = .KorFont(style: .medium, size: 14)
+        view.textColor = UIColor.g1000
+        return view
+    }()
+    
+    let clearButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(named: "cancel_signUp"), for: .normal)
+        return button
+    }()
+    
+    let bottomStackView: UIStackView = {
+        let view = UIStackView()
+        view.layoutMargins = .init(top: 0, left: 4, bottom: 0, right: 4)
+        view.isLayoutMarginsRelativeArrangement = true
+        return view
+    }()
+    
+    let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .regular, size: 12)
+        label.textColor = UIColor.g500
+        return label
+    }()
+    
+    let textCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .regular, size: 12)
+        label.textAlignment = .right
+        label.textColor = UIColor.g500
+        return label
+    }()
+    
+    // MARK: - Properties
+    
+    let limitTextCount: Int
+    
+    let disposeBag = DisposeBag()
+    
+    // MARK: - init
+    
+    init(isEnable: Bool = true, placeHolder: String?, description: String? = nil, limitTextCount: Int? = nil) {
+        if let limitTextCount = limitTextCount {
+            self.limitTextCount = limitTextCount
+        } else {
+            self.limitTextCount = 0
+        }
+        super.init(frame: .zero)
+        setUp(isEnable: isEnable, placeHolder: placeHolder, description: description, limitTextCount: limitTextCount)
+        setUpConstraints(description: description, limitTextCount: limitTextCount)
+        bind()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - SetUp
+
+private extension BaseTextFieldCPNT {
+    func setUp(isEnable: Bool, placeHolder: String?, description: String?, limitTextCount: Int?) {
+        self.axis = .vertical
+        self.spacing = 6
+        
+        textField.placeholder = placeHolder
+        descriptionLabel.text = description
+        textCountLabel.text = "0 / \(self.limitTextCount)자"
+        
+        if !isEnable {
+            self.isUserInteractionEnabled = false
+            self.textFieldBackGroundView.backgroundColor = .pb4
+        }
+    }
+    
+    func setUpConstraints(description: String?, limitTextCount: Int?) {
+        clearButton.snp.makeConstraints { make in
+            make.size.equalTo(20)
+        }
+        textField.snp.makeConstraints { make in
+            make.height.equalTo(20)
+        }
+        textFieldBackGroundView.addSubview(textFieldStackView)
+        textFieldStackView.addArrangedSubview(textField)
+        textFieldStackView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.top.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview().inset(15)
+        }
+        
+        if let _ = description {
+            bottomStackView.addArrangedSubview(descriptionLabel)
+        }
+        
+        if let _ = limitTextCount {
+            bottomStackView.addArrangedSubview(textCountLabel)
+        }
+        self.addArrangedSubview(textFieldBackGroundView)
+        if description != nil || limitTextCount != nil {
+            self.addArrangedSubview(bottomStackView)
+        }
+    }
+    
+    func bind() {
+        textField.rx.controlEvent(.editingDidBegin)
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.textFieldBackGroundView.layer.borderColor = UIColor.g1000.cgColor
+                owner.textFieldStackView.addArrangedSubview(owner.clearButton)
+            }
+            .disposed(by: disposeBag)
+        
+        textField.rx.text
+            .orEmpty
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                owner.textCountLabel.text = "\(text.count) / \(owner.limitTextCount)자"
+            }
+            .disposed(by: disposeBag)
+        
+        textField.rx.controlEvent(.editingDidEnd)
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.textFieldBackGroundView.layer.borderColor = UIColor.g100.cgColor
+                owner.clearButton.removeFromSuperview()
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/PopPool/PopPool/Presentation/Components/ValidationTextFieldCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ValidationTextFieldCPNT.swift
@@ -88,9 +88,9 @@ final class ValidationTextFieldCPNT: BaseTextFieldCPNT {
         /// state별로 x 버튼의 출력 여부
         var isClearButtonHidden: Bool {
             switch state {
-            case .shortText, .buttonTapError, .overText, .requestButtonTap:
+            case .shortText, .buttonTapError, .overText, .requestButtonTap, .requestKorOrEn:
                 return false
-            case .none, .requestKorOrEn, .valid:
+            case .none, .valid:
                 return true
             }
         }

--- a/PopPool/PopPool/Presentation/Components/ValidationTextFieldCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ValidationTextFieldCPNT.swift
@@ -2,314 +2,253 @@
 //  ValidationTextFieldCPNT.swift
 //  PopPool
 //
-//  Created by SeoJunYoung on 6/29/24.
+//  Created by SeoJunYoung on 7/8/24.
 //
 
 import UIKit
 import SnapKit
-import RxCocoa
 import RxSwift
+import RxCocoa
 
-final class ValidationTextFieldCPNT: UIStackView {
+final class ValidationTextFieldCPNT: BaseTextFieldCPNT {
     
-    enum NickNameValidationState {
-        case available
+    enum ValidationType {
+        case nickName
+    }
+    
+    /// 입력 상태를 정리하기 위한 enum입니다
+    /// 텍스트필드별 추가되는 상태를 적용해주세요
+    enum ValidationState {
         case none
-        case requiredDuplicateCheck
-        case requiredKrOrEn
-        case shortLength
-        case longLength
-        case duplicateNickname
+        case requestKorOrEn
+        case requestButtonTap
+        case overText
+        case shortText
+        case buttonTapError
+        case valid
+    }
+    
+    struct ValidationOutPut {
+        var type: ValidationType
+        var state: ValidationState
         
         var description: String? {
-            switch self {
-            case .available:
-                return "사용 가능한 별명이에요"
+            switch state {
             case .none:
                 return nil
-            case .requiredDuplicateCheck:
-                return "중복체크를 진행해주세요"
-            case .requiredKrOrEn:
+            case .requestKorOrEn:
                 return "한글, 영문으로만 입력해주세요"
-            case .shortLength:
-                return "2글자 이상 입력해주세요"
-            case .longLength:
+            case .requestButtonTap:
+                return "중복체크를 진행해주세요"
+            case .overText:
                 return "10글자까지만 입력할 수 있어요"
-            case .duplicateNickname:
+            case .shortText:
+                return "2글자 이상 입력해주세요"
+            case .buttonTapError:
                 return "이미 사용되고 있는 별명이에요"
+            case .valid:
+                return "사용 가능한 별명이에요"
             }
         }
         
-        var descriptionIsHidden: Bool {
-            switch self {
-            case .none:
-                return true
-            default:
-                return false
-            }
-        }
+        /// 텍스트필드를 감싸는 view의 컬러값
         var borderColor: UIColor {
-            switch self {
-            case .none:
-                return .g200
-            case .available, .requiredDuplicateCheck:
-                return .g700
-            default:
-                return .re500
+            switch state {
+            case .overText, .buttonTapError, .shortText, .requestKorOrEn:
+                return UIColor.re500
+            case .none, .requestButtonTap:
+                return UIColor.g100
+            case .valid:
+                return UIColor.g1000
             }
         }
-        var cancelButtonIsHidden: Bool {
-            switch self {
-            case .requiredDuplicateCheck:
-                return true
+        
+        /// 텍스트필드 하단의 획의 count 컬러값
+        var countLabelColor: UIColor {
+            switch state {
+            case .overText, .shortText:
+                return UIColor.re500
             default:
-                return false
+                return UIColor.g500
             }
         }
-        var duplicateCheckButtonIsHidden: Bool {
-            switch self {
-            case .requiredDuplicateCheck:
-                return false
-            default:
-                return true
-            }
-        }
-        var textColor: UIColor {
-            switch self {
-            case .available, .requiredDuplicateCheck, .none:
-                return .g1000
-            default:
-                return .re500
-            }
-        }
+        
+        /// 텍스트필드 하단의 각 설명의 컬러값
         var descriptionColor: UIColor {
-            switch self {
-            case .available:
-                return .blu500
-            case .requiredDuplicateCheck:
-                return .g500
-            default:
-                return .re500
+            switch state {
+            case .overText, .buttonTapError, .shortText, .requestKorOrEn:
+                return UIColor.re500
+            case .none, .requestButtonTap:
+                return UIColor.g500
+            case .valid:
+                return UIColor.blu500
             }
-            
         }
-        var countColor: UIColor {
-            switch self {
-            case .available, .requiredDuplicateCheck, .none:
-                return .g500
+        
+        /// state별로 x 버튼의 출력 여부
+        var isClearButtonHidden: Bool {
+            switch state {
+            case .none, .requestKorOrEn, .requestButtonTap, .valid:
+                return true
+            case .shortText, .buttonTapError, .overText:
+                return false
+            }
+        }
+        
+        /// state별로 '중복체크' 버튼의 출력 여부
+        var isDuplicateCheckButtonHidden: Bool {
+            switch state {
+            case .none, .shortText, .overText, .buttonTapError:
+                return true
+            case .requestButtonTap:
+                return false
             default:
-                return .re500
+                return false
             }
         }
     }
     
     // MARK: - Components
-    private let textFieldTrailingView: UIView = {
-        let view = UIView()
-        return view
+    
+    private let checkValidationStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        return stack
     }()
-    private let textFieldStackView: UIStackView = {
-        let view = UIStackView()
-        view.spacing = 1
-        return view
-    }()
-    private let textField: UITextField = {
-        let textField = UITextField()
-        textField.font = .KorFont(style: .medium, size: 14)
-        return textField
-    }()
-    private let cancelButton: UIButton = {
-        let button = UIButton()
-        let backgroudImage = UIImage(named: "cancel_signUp")
-        button.setBackgroundImage(backgroudImage, for: .normal)
-        button.setBackgroundImage(backgroudImage, for: .highlighted)
-        return button
-    }()
-    private let duplicationCheckStackView: UIStackView = {
-        let view = UIStackView()
-        view.axis = .vertical
-        view.isHidden = true
-        return view
-    }()
-    let duplicationCheckButton: UIButton = {
+    
+    let checkValidationButton: UIButton = {
         let button = UIButton()
         button.setTitle("중복체크", for: .normal)
         button.titleLabel?.font = .KorFont(style: .regular, size: 13)
         button.setTitleColor(.g1000, for: .normal)
         return button
     }()
-    private let lineView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .g1000
-        return view
-    }()
-    private let validationStackView: UIStackView = {
-        let view = UIStackView()
-        view.directionalLayoutMargins = .init(top: 0, leading: 4, bottom: 0, trailing: 4)
-        view.isLayoutMarginsRelativeArrangement = true
-        return view
-    }()
-    private let validationLabel: UILabel = {
-        let label = UILabel()
-        label.font = .KorFont(style: .regular, size: 12)
-        label.text = "하이"
-        return label
-    }()
-    private let textCountLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment = .right
-        label.font = .KorFont(style: .regular, size: 12)
-        label.textColor = .g500
-        return label
+    
+    private let checkValidationLine: UIView = {
+        let line = UIView()
+        line.layer.borderColor = UIColor.g300.cgColor
+        line.layer.borderWidth = 1
+        return line
     }()
     
-    let validationState: BehaviorRelay<NickNameValidationState> = .init(value: .none)
-    let nickNameObserver: PublishSubject<String?> = .init()
-    private let disposeBag = DisposeBag()
+    // MARK: - Properties
     
-    init(placeholder: String) {
-        super.init(frame: .zero)
-        setUp(placeholder: placeholder)
-        setUpConstraints()
+    /// 상태 값의 변화를 감지하는 옵저버
+    /// bind()에서 텍스트필드의 입력 값에 따라 변경된 값을 적용하는 것을 돕습니다
+    let stateObserver:PublishSubject<ValidationState> = .init()
+    let nameObserver: PublishSubject<String?> = .init()
+    private let type: ValidationType
+    
+    // MARK: - Initializer
+    
+    init(placeHolder: String?, type: ValidationType = .nickName, limitTextCount: Int) {
+        self.type = type
+        super.init(placeHolder: placeHolder, description: "", limitTextCount: limitTextCount)
+        setUpDuplicatecheck()
         bind()
+    }
+    
+    // MARK: - Methods
+    
+    private func setUpDuplicatecheck() {
+        checkValidationStack.addArrangedSubview(checkValidationButton)
+        checkValidationStack.addArrangedSubview(checkValidationLine)
+        checkValidationLine.snp.makeConstraints { make in
+            make.height.equalTo(1)
+        }
+        textFieldStackView.addArrangedSubview(checkValidationStack)
+    }
+    
+    private func bind() {
+        textField.rx.text.orEmpty
+            .withUnretained(self)
+            .subscribe { (owner, text) in
+                let state = owner.fetchValidationState(text: text)
+                owner.stateObserver.onNext(state)
+                print(text)
+                print("상태는 이렇습니다", state)
+                
+                // show when text is empty?
+                owner.clearButton.isHidden = text.isEmpty
+                owner.checkValidationStack.isHidden = !text.isEmpty
+            }
+            .disposed(by: disposeBag)
+        
+        stateObserver
+            .withUnretained(self)
+            .subscribe { (owner, state) in
+                let output = ValidationOutPut(type: owner.type, state: state)
+                owner.setUpViewFrom(output: output)
+                
+                // 다음 버튼을 활성화하기 위한 값을 넘기는 동작 - But 검수를 진행하지 않음
+                print("상태 값 =", state)
+                if state == .valid {
+                    guard let nickName = owner.textField.text else { return }
+                    print("값이 넘어왔어요",nickName)
+                    self.nameObserver.onNext(nickName)
+                } else {
+                    self.nameObserver.onNext(nil)
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        clearButton.rx.tap
+            .withUnretained(self)
+            .subscribe { (owner, value) in
+                owner.textField.text = ""
+                // hide when tapped
+                owner.clearButton.isHidden = true
+            }
+            .disposed(by: disposeBag)
+        
+        textField.rx.controlEvent(.editingDidEnd)
+            .withUnretained(self)
+            .subscribe { (owner, _) in
+                owner.checkValidationStack.isHidden = false
+                owner.clearButton.isHidden = true
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    /// 텍스트필드 입력 값에 반응하는 메서드
+    /// - Parameter text: 텍스트 필드에 입력된 String 타입을 받습니다
+    /// - Returns: ValidationState로 상태 값을 반환합니다
+    private func fetchValidationState(text: String) -> ValidationState {
+        if text.count == 0 {
+            return .none
+        } else if text.count < 2 {
+            return .shortText
+        } else if text.count > 10 {
+            return .overText
+        }
+        
+        // 국문, 영문을 확인하는 Regex 코드
+        let regex = "^[가-힣A-Za-z0-9\\s]*$"
+        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
+        if !predicate.evaluate(with: text) {
+            return .requestKorOrEn
+        }
+        return .requestButtonTap
+    }
+    
+    /// ValidationOutput 상태 값에 반응하는 메서드
+    /// 상태에 맞는 컬러 값을 바꾸고 특정 버튼 등을 숨김 처리합니다.
+    /// - Parameter output: 상태 값 타입인 ValidationOutPut을 받습니다
+    private func setUpViewFrom(output: ValidationOutPut) {
+        print(#function)
+        
+        // 색상 적용
+        self.descriptionLabel.text = output.description
+        self.descriptionLabel.textColor = output.descriptionColor
+        self.textFieldBackGroundView.layer.borderColor = output.borderColor.cgColor
+        self.textCountLabel.textColor = output.countLabelColor
+        
+        // 텍스트 필드 반전
+//        self.clearButton.isHidden = output.isClearButtonHidden
+//        self.checkValidationStack.isHidden = output.isDuplicateCheckButtonHidden
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-}
-// MARK: - SetUp
-private extension ValidationTextFieldCPNT {
-    
-    /// 초기 설정을 수행하는 메서드
-    /// - Parameter placeholder: 텍스트 필드의 플레이스홀더
-    func setUp(placeholder: String) {
-        self.axis = .vertical
-        self.spacing = 6
-        textFieldTrailingView.layer.borderWidth = 1.2
-        textFieldTrailingView.layer.borderColor = UIColor.g100.cgColor
-        textFieldTrailingView.layer.cornerRadius = 4
-        
-        textField.attributedPlaceholder = NSAttributedString(
-            string: placeholder,
-            attributes: [
-                .foregroundColor: UIColor.g200,
-                .font: UIFont.KorFont(style: .medium, size: 14)!
-            ]
-        )
-    }
-    
-    /// 제약 조건을 설정하는 메서드
-    func setUpConstraints() {
-        textFieldTrailingView.addSubview(textFieldStackView)
-        textFieldStackView.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(Constants.spaceGuide.small200)
-            make.top.equalToSuperview().inset(16)
-            make.height.equalTo(21)
-            make.bottom.equalToSuperview().inset(15)
-        }
-        validationStackView.addArrangedSubview(validationLabel)
-        validationStackView.addArrangedSubview(textCountLabel)
-        validationLabel.snp.makeConstraints { make in
-            make.height.equalTo(18)
-        }
-        duplicationCheckStackView.addArrangedSubview(duplicationCheckButton)
-        duplicationCheckStackView.addArrangedSubview(lineView)
-        duplicationCheckButton.snp.makeConstraints { make in
-            make.height.equalTo(20)
-        }
-        lineView.snp.makeConstraints { make in
-            make.height.equalTo(1)
-        }
-        textFieldStackView.addArrangedSubview(textField)
-        textFieldStackView.addArrangedSubview(cancelButton)
-        textFieldStackView.addArrangedSubview(duplicationCheckStackView)
-        cancelButton.snp.makeConstraints { make in
-            make.width.equalTo(21)
-        }
-        self.addArrangedSubview(textFieldTrailingView)
-        self.addArrangedSubview(validationStackView)
-    }
-    
-    /// 바인딩 설정을 수행하는 메서드
-    func bind() {
-        textField.rx.text.orEmpty
-            .withUnretained(self)
-            .debounce(.microseconds(300), scheduler: MainScheduler.instance)
-            .subscribe { (owner, nickName) in
-                owner.changeNickNameCount(nickname: nickName)
-                owner.checkValidation(nickName: nickName)
-            } onError: { error in
-                ToastMSGManager.createToast(message: "TextFieldError")
-            }
-            .disposed(by: disposeBag)
-        validationState
-            .withUnretained(self)
-            .subscribe { (owner, state) in
-                if state == .available {
-                    guard let nickName = owner.textField.text else { return }
-                    owner.nickNameObserver.onNext(nickName)
-                } else {
-                    owner.nickNameObserver.onNext(nil)
-                }
-                owner.changeView(state: state)
-            } onError: { error in
-                ToastMSGManager.createToast(message: "ValidationStateError")
-            }
-            .disposed(by: disposeBag)
-        
-        cancelButton.rx.tap
-            .withUnretained(self)
-            .subscribe { (owner, _) in
-                owner.textField.text = ""
-                owner.validationState.accept(.none)
-                owner.changeNickNameCount(nickname: "")
-            }
-            .disposed(by: disposeBag)
-    }
-    
-    /// nickName 유효성을 검사하는 메서드
-    /// - Parameter nickName: 입력된 별명
-    func checkValidation(nickName: String) {
-        if nickName.count == 0 {
-            validationState.accept(.none)
-            return
-        }
-        if nickName.count < 2 {
-            validationState.accept(.shortLength)
-            return
-        }
-        if nickName.count > 10 {
-            validationState.accept(.longLength)
-            return
-        }
-        
-        // 한글, 영어, 숫자, 공백을 허용하는 정규 표현식
-        let regex = "^[가-힣A-Za-z0-9\\s]*$"
-        let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
-        if !predicate.evaluate(with: nickName) {
-            validationState.accept(.requiredKrOrEn)
-            return
-        }
-        validationState.accept(.requiredDuplicateCheck)
-    }
-    
-    /// 뷰를 변경하는 메서드
-    /// - Parameter state: 닉네임 유효성 상태
-    func changeView(state: NickNameValidationState) {
-            self.validationLabel.isHidden = state.descriptionIsHidden
-            self.cancelButton.isHidden = state.cancelButtonIsHidden
-            self.validationLabel.text = state.description
-            self.textFieldTrailingView.layer.borderColor = state.borderColor.cgColor
-            self.duplicationCheckStackView.isHidden = state.duplicateCheckButtonIsHidden
-            self.textCountLabel.textColor = state.countColor
-            self.validationLabel.textColor = state.descriptionColor
-    }
-    
-    /// 닉네임 글자 수를 변경하는 메서드
-    /// - Parameter nickname: 입력된 닉네임
-    func changeNickNameCount(nickname: String) {
-        let count = nickname.count
-            self.textCountLabel.text = "\(count) / 10 자"
     }
 }

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
@@ -167,12 +167,12 @@ private extension SignUpVC {
     func bind() {
         
         // 중복확인 버튼 클릭시 키보드 다운 처리
-        step2_ContentView.validationTextField.duplicationCheckButton.rx.tap
-            .withUnretained(self)
-            .subscribe { (owner, _) in
-                owner.view.endEditing(true)
-            }
-            .disposed(by: disposeBag)
+//        step2_ContentView.validationTextField.duplicationCheckButton.rx.tap
+//            .withUnretained(self)
+//            .subscribe { (owner, _) in
+//                owner.view.endEditing(true)
+//            }
+//            .disposed(by: disposeBag)
         
         // MARK: - Input
         let input = SignUpVM.Input(
@@ -182,8 +182,8 @@ private extension SignUpVC {
             event_step1_didChangeTerms: step1_ContentView.terms,
             tap_step1_termsButton: step1_ContentView.didTapTerms,
             tap_step2_primaryButton: step2_primaryButton.rx.tap,
-            tap_step2_nickNameCheckButton: step2_ContentView.validationTextField.duplicationCheckButton.rx.tap,
-            event_step2_availableNickName: step2_ContentView.validationTextField.nickNameObserver,
+//            tap_step2_nickNameCheckButton: step2_ContentView.validationTextField.duplicationCheckButton.rx.tap,
+//            event_step2_availableNickName: step2_ContentView.validationTextField.nickNameObserver,
             tap_step3_primaryButton: step3_primaryButton.rx.tap,
             tap_step3_secondaryButton: step3_secondaryButton.rx.tap,
             event_step3_didChangeInterestList: step3_ContentView.fetchSelectedList(),
@@ -246,7 +246,7 @@ private extension SignUpVC {
             .withUnretained(self)
             .debounce(.microseconds(200), scheduler: MainScheduler.instance)
             .subscribe { (owner, isDuplicate) in
-                owner.step2_ContentView.validationTextField.validationState.accept(isDuplicate ? .duplicateNickname : .available)
+//                owner.step2_ContentView.validationTextField.stateObserver.accept(isDuplicate ? .requestButtonTap : .valid)
             }
             .disposed(by: disposeBag)
         

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
@@ -31,9 +31,9 @@ final class SignUpVM: ViewModelable {
         /// Sign Up Step2 primary button  탭 이벤트
         var tap_step2_primaryButton: ControlEvent<Void>
         /// Sign Up Step2 중복확인 button  탭 이벤트
-        var tap_step2_nickNameCheckButton: ControlEvent<Void>
+//        var tap_step2_nickNameCheckButton: ControlEvent<Void>
         /// Sign Up Step2 유효한 닉네임 전달 이벤트
-        var event_step2_availableNickName: PublishSubject<String?>
+//        var event_step2_availableNickName: PublishSubject<String?>
         
         // MARK: - Step 3 Input
         /// Sign Up Step3 primary button  탭 이벤트
@@ -191,26 +191,26 @@ final class SignUpVM: ViewModelable {
             .disposed(by: disposeBag)
         
         // Step2 중복확인 버튼 이벤트 처리
-        input.tap_step2_nickNameCheckButton
-            .subscribe { _ in
-                // 네트워크 사용으로 수정 필요
-                step2_isDuplicate.onNext(false)
-            }
-            .disposed(by: disposeBag)
+//        input.tap_step2_nickNameCheckButton
+//            .subscribe { _ in
+//                // 네트워크 사용으로 수정 필요
+//                step2_isDuplicate.onNext(false)
+//            }
+//            .disposed(by: disposeBag)
         
         // Step2 nickName Validation 상태 이벤트 처리
-        input.event_step2_availableNickName
-            .withUnretained(self)
-            .subscribe(onNext: { (owner, nickname) in
-                if let nickname = nickname {
-                    owner.userNickName.onNext(nickname)
-                    step2_primaryButton_isEnabled.onNext(true)
-                } else {
-                    owner.userNickName.onNext("error")
-                    step2_primaryButton_isEnabled.onNext(false)
-                }
-            })
-            .disposed(by: disposeBag)
+//        input.event_step2_availableNickName
+//            .withUnretained(self)
+//            .subscribe(onNext: { (owner, nickname) in
+//                if let nickname = nickname {
+//                    owner.userNickName.onNext(nickname)
+//                    step2_primaryButton_isEnabled.onNext(true)
+//                } else {
+//                    owner.userNickName.onNext("error")
+//                    step2_primaryButton_isEnabled.onNext(false)
+//                }
+//            })
+//            .disposed(by: disposeBag)
         
         // MARK: - Step 3 transform
         // 관심사 리스트 변경 이벤트 처리

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep2View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep2View.swift
@@ -11,7 +11,7 @@ import SnapKit
 final class SignUpStep2View: UIStackView {
     // MARK: - Components
     private let topSpacingView = UIView()
-    let validationTextField = ValidationTextFieldCPNT(placeholder: "별명을 입력해주세요")
+    let validationTextField = ValidationTextFieldCPNT(placeHolder: "별명을 입력해주세요", limitTextCount: 10)
     private let bottomSpacingView = UIView()
     
     // MARK: - init


### PR DESCRIPTION
## Description
- 이전 브랜치는 project 이슈가 발생하여 새로운 브랜치에 validationTF 관련 코드를 올립니다.

## Changes
- 텍스트 필드 입력 데이터에 따라 컬러가 올바르게 바뀝니다.
- 타입 중인 상황에서 clearbutton이 보입니다
- 타입을 멈추고 키보드를 내렸을 때 중복 체크 버튼이 활성화 됩니다

**- screen2의 코드들은 모두 연결 해제해둔 상태입니다**


https://github.com/PopPool/iOS/assets/119504454/ba770ad0-e920-4ca6-a220-4d4a05d79657

