### PR TITLE
[MERGE] : ✅ 내 코멘트 Cell 개발, TableViewSectionable Cell Output 헨들링 추가, 등

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -85,6 +85,9 @@
 		08C813F72C2F15DC009239FE /* InterestListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813F62C2F15DC009239FE /* InterestListResponseDTO.swift */; };
 		08C813FB2C2F2809009239FE /* SignUpRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813FA2C2F2809009239FE /* SignUpRequestDTO.swift */; };
 		08C813FD2C2F2C14009239FE /* SignUpRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C813FC2C2F2C13009239FE /* SignUpRepository.swift */; };
+		08E23A3B2C4502E5004B77B6 /* CircleFeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A3A2C4502E5004B77B6 /* CircleFeedCell.swift */; };
+		08E23A3F2C452523004B77B6 /* MenuListCellSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A3E2C452523004B77B6 /* MenuListCellSection.swift */; };
+		08E23A412C452571004B77B6 /* MyCommentCircleListCellSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A402C452571004B77B6 /* MyCommentCircleListCellSection.swift */; };
 		08F49DDB2C200528002D5202 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DDA2C200528002D5202 /* AuthService.swift */; };
 		08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE92C231CFC002D5202 /* LoginResponse.swift */; };
 		08F49DEC2C231D13002D5202 /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */; };
@@ -223,6 +226,9 @@
 		08C813F62C2F15DC009239FE /* InterestListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestListResponseDTO.swift; sourceTree = "<group>"; };
 		08C813FA2C2F2809009239FE /* SignUpRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRequestDTO.swift; sourceTree = "<group>"; };
 		08C813FC2C2F2C13009239FE /* SignUpRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRepository.swift; sourceTree = "<group>"; };
+		08E23A3A2C4502E5004B77B6 /* CircleFeedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleFeedCell.swift; sourceTree = "<group>"; };
+		08E23A3E2C452523004B77B6 /* MenuListCellSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuListCellSection.swift; sourceTree = "<group>"; };
+		08E23A402C452571004B77B6 /* MyCommentCircleListCellSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCommentCircleListCellSection.swift; sourceTree = "<group>"; };
 		08F49DDA2C200528002D5202 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		08F49DE92C231CFC002D5202 /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
 		08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDTO.swift; sourceTree = "<group>"; };
@@ -529,6 +535,7 @@
 		089D19202C391275000435D9 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				08E23A3D2C452515004B77B6 /* TableViewSection */,
 				08B183B42C3D948C006C34BB /* UITableViewCell */,
 				089D19212C391293000435D9 /* UICollectionViewCell */,
 			);
@@ -539,6 +546,7 @@
 			isa = PBXGroup;
 			children = (
 				08C813DA2C2D3A58009239FE /* LargeChipCell.swift */,
+				08E23A3A2C4502E5004B77B6 /* CircleFeedCell.swift */,
 			);
 			path = UICollectionViewCell;
 			sourceTree = "<group>";
@@ -729,6 +737,15 @@
 				08C813FA2C2F2809009239FE /* SignUpRequestDTO.swift */,
 			);
 			path = SignUpDTO;
+			sourceTree = "<group>";
+		};
+		08E23A3D2C452515004B77B6 /* TableViewSection */ = {
+			isa = PBXGroup;
+			children = (
+				08E23A3E2C452523004B77B6 /* MenuListCellSection.swift */,
+				08E23A402C452571004B77B6 /* MyCommentCircleListCellSection.swift */,
+			);
+			path = TableViewSection;
 			sourceTree = "<group>";
 		};
 		08F49DE62C231C30002D5202 /* Enums */ = {
@@ -1154,6 +1171,7 @@
 				08B9658F2C16004D00BF95AA /* PopPoolAPIEndPoint.swift in Sources */,
 				BD9901CD2C2877BF0024F30D /* ToastMSGCPNT.swift in Sources */,
 				BDD3351A2C0B3AF1002C2295 /* NetworkError.swift in Sources */,
+				08E23A3F2C452523004B77B6 /* MenuListCellSection.swift in Sources */,
 				BD27D0902C35A9020092FC36 /* FetchLocalUseCaseImpl.swift in Sources */,
 				08F49E0B2C240345002D5202 /* _@_@_.swift in Sources */,
 				08B965602C1441C100BF95AA /* AppleAuthServiceImpl.swift in Sources */,
@@ -1177,6 +1195,8 @@
 				BDA0B1342C2DD102007BDCA4 /* Factory.swift in Sources */,
 				08B9658A2C15FEBF00BF95AA /* FetchSocialCredentialUseCaseImpl.swift in Sources */,
 				BD54FA5B2C3F743B00D685A6 /* DynamicTextViewCPNT.swift in Sources */,
+				08E23A3B2C4502E5004B77B6 /* CircleFeedCell.swift in Sources */,
+				08E23A412C452571004B77B6 /* MyCommentCircleListCellSection.swift in Sources */,
 				BD1D886C2C3D958D00380F80 /* BaseTextFieldCPNT.swift in Sources */,
 				08F49DF02C2321B8002D5202 /* AuthRepositoryImpl.swift in Sources */,
 				BDF4F2962C240B95002F4F03 /* UIColor+.swift in Sources */,

--- a/PopPool/PopPool/Presentation/Common/Cells/TableViewSection/MenuListCellSection.swift
+++ b/PopPool/PopPool/Presentation/Common/Cells/TableViewSection/MenuListCellSection.swift
@@ -1,0 +1,65 @@
+//
+//  MenuListCellSection.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 7/15/24.
+//
+
+import UIKit
+import RxSwift
+
+struct MenuListCellSection: TableViewSectionable {
+    
+    struct Input {
+        var sectionTitle: String?
+    }
+    
+    struct Output {
+    }
+    
+    typealias CellType = MenuListCell
+    
+    
+    var sectionInput: Input
+    
+    var sectionCellOutput: PublishSubject<(MenuListCell.Output, IndexPath)> = .init()
+    
+    var sectionCellInputList: [MenuListCell.Input]
+
+    func makeHeaderView() -> UIView? {
+        let containerView = UIView()
+        let titleView = ListTitleViewCPNT(title: sectionInput.sectionTitle, size: .medium)
+        titleView.titleLabel.font = .KorFont(style: .bold, size: 16)
+        titleView.rightButton.isHidden = true
+        let topView = UIView()
+        containerView.backgroundColor = .systemBackground
+        topView.backgroundColor = .g50
+
+        containerView.addSubview(topView)
+        topView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.height.equalTo(Constants.spaceGuide.small100)
+        }
+        if sectionInput.sectionTitle != nil {
+            containerView.addSubview(titleView)
+            titleView.snp.makeConstraints { make in
+                make.leading.trailing.equalToSuperview().inset(20)
+                make.top.equalTo(topView.snp.bottom).offset(Constants.spaceGuide.small400)
+                make.bottom.equalToSuperview().inset(Constants.spaceGuide.small400)
+            }
+        } else {
+            topView.snp.makeConstraints { make in
+                make.bottom.equalToSuperview().inset(Constants.spaceGuide.small400)
+            }
+        }
+        return containerView
+    }
+    
+    func sectionOutput() -> Output {
+        return Output()
+    }
+    
+    func makeFooterView() -> UIView? {
+        return nil
+    }
+}

--- a/PopPool/PopPool/Presentation/Common/Cells/TableViewSection/MyCommentCircleListCellSection.swift
+++ b/PopPool/PopPool/Presentation/Common/Cells/TableViewSection/MyCommentCircleListCellSection.swift
@@ -1,0 +1,56 @@
+//
+//  MyCommentCircleListCellSection.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 7/15/24.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+// TODO: - 수정필요
+struct MyCommentCircleListCellSection: TableViewSectionable {
+    
+    struct Input {
+        var sectionTitle: String?
+    }
+    
+    struct Output {
+        var didTapRightButton: ControlEvent<Void>
+    }
+    
+    typealias CellType = MyCommentCircleListCell
+    
+    var sectionInput: Input
+    
+    var sectionCellInputList: [MyCommentCircleListCell.Input]
+    
+    var sectionCellOutput: PublishSubject<(MyCommentCircleListCell.Output, IndexPath)> = .init()
+    
+    lazy var titleView: ListTitleViewCPNT = {
+        let view = ListTitleViewCPNT(title: sectionInput.sectionTitle, size: .medium)
+        view.titleLabel.font = .KorFont(style: .bold, size: 16)
+        return view
+    }()
+    
+    mutating func makeHeaderView() -> UIView? {
+        let containerView = UIView()
+        containerView.backgroundColor = .systemBackground
+        containerView.addSubview(titleView)
+        titleView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.top.equalToSuperview()
+            make.bottom.equalToSuperview().inset(Constants.spaceGuide.small100)
+        }
+        return containerView
+    }
+    
+    mutating func sectionOutput() -> Output {
+        return Output(didTapRightButton: titleView.rightButton.rx.tap)
+    }
+    
+    func makeFooterView() -> UIView? {
+        return nil
+    }
+}

--- a/PopPool/PopPool/Presentation/Common/Cells/UICollectionViewCell/CircleFeedCell.swift
+++ b/PopPool/PopPool/Presentation/Common/Cells/UICollectionViewCell/CircleFeedCell.swift
@@ -1,0 +1,160 @@
+//
+//  CircleFeedCell.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 7/15/24.
+//
+
+import UIKit
+import SnapKit
+
+final class CircleFeedCell: UICollectionViewCell {
+    // MARK: - Components
+    private let colorBackGroundView = AnimatedGradientView()
+    private let imageBackGroundView = UIView()
+    private let imageView = UIImageView()
+    private let titleLabel = UILabel()
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUp()
+        setUpConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - SetUp
+private extension CircleFeedCell {
+    func setUp() {
+        contentView.backgroundColor = .clear
+        colorBackGroundView.contentMode = .scaleAspectFill
+        colorBackGroundView.layer.cornerRadius = contentView.bounds.width / 2
+        colorBackGroundView.clipsToBounds = true
+        colorBackGroundView.backgroundColor = .g100
+        
+        imageBackGroundView.backgroundColor = .systemBackground
+        imageBackGroundView.layer.cornerRadius = (contentView.bounds.width - (3 * 2)) / 2
+        imageBackGroundView.clipsToBounds = true
+        
+        imageView.layer.cornerRadius = (contentView.bounds.width - (3 * 4)) / 2
+        imageView.clipsToBounds = true
+        titleLabel.font = .KorFont(style: .regular, size: 11)
+        titleLabel.textColor = .g1000
+        titleLabel.textAlignment = .center
+    }
+    
+    func setUpConstraints() {
+        contentView.addSubview(colorBackGroundView)
+        colorBackGroundView.snp.makeConstraints { make in
+            make.size.equalTo(contentView.bounds.width)
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview()
+        }
+        colorBackGroundView.addSubview(imageBackGroundView)
+        imageBackGroundView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(3)
+        }
+        
+        imageBackGroundView.addSubview(imageView)
+        imageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(3)
+        }
+        
+        contentView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.bottom.leading.trailing.equalToSuperview()
+            make.height.equalTo(17)
+        }
+    }
+}
+
+// MARK: - Cellable
+extension CircleFeedCell: Cellable {
+
+    struct Input {
+        var title: String?
+        var isActive: Bool
+        var image: UIImage?
+    }
+    
+    struct Output {
+        
+    }
+    
+    func injectionWith(input: Input) {
+        titleLabel.text = input.title
+        imageView.image = input.image
+        if input.isActive {
+            colorBackGroundView.startAnimatingGradient()
+        } else {
+            colorBackGroundView.stopAnimatingGradient()
+        }
+    }
+    
+    func getOutput() -> Output {
+        return Output()
+    }
+}
+
+// MARK: - AnimatedGradientView
+class AnimatedGradientView: UIView {
+    
+    private var gradientLayer: CAGradientLayer!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupGradient()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupGradient()
+    }
+    
+    private func setupGradient() {
+        let startColor = UIColor.init(hexCode: "00E6BD")
+        let endColor = UIColor.init(hexCode: "1570FC")
+
+        gradientLayer = CAGradientLayer()
+        gradientLayer.frame = bounds
+        gradientLayer.colors = [startColor.cgColor, endColor.cgColor]
+        gradientLayer.locations = [0.0, 1.0]
+        
+        layer.addSublayer(gradientLayer)
+    }
+    
+    func startAnimatingGradient() {
+        let newColors: [CGColor] = [
+            UIColor.init(hexCode: "00E6BD").cgColor,
+            UIColor.init(hexCode: "3BA5C3").cgColor,
+            UIColor.init(hexCode: "1D88A5").cgColor,
+            UIColor.init(hexCode: "6196C5").cgColor,
+            UIColor.init(hexCode: "468CAE").cgColor,
+            UIColor.init(hexCode: "1570FC").cgColor,
+        ]
+        
+        let animation = CABasicAnimation(keyPath: "colors")
+        animation.fromValue = gradientLayer.colors
+        animation.toValue = newColors
+        animation.duration = 3.0
+        animation.autoreverses = true
+        animation.repeatCount = .infinity
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        
+        gradientLayer.add(animation, forKey: "animateGradient")
+    }
+    
+    func stopAnimatingGradient() {
+        gradientLayer.removeAllAnimations()
+        gradientLayer.removeFromSuperlayer()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gradientLayer.frame = bounds
+    }
+}

--- a/PopPool/PopPool/Presentation/Common/Cells/UITableViewCell/MenuListCell.swift
+++ b/PopPool/PopPool/Presentation/Common/Cells/UITableViewCell/MenuListCell.swift
@@ -7,59 +7,7 @@
 
 import UIKit
 import SnapKit
-
-struct MenuListCellSection: TableViewSectionable {
-    
-    struct Input {
-        var sectionTitle: String?
-    }
-    
-    struct Output {
-    }
-    
-    typealias CellType = MenuListCell
-    
-    var sectionInput: Input
-
-    var sectionCellInputList: [MenuListCell.Input]
-
-    func makeHeaderView() -> UIView? {
-        let containerView = UIView()
-        let titleView = ListTitleViewCPNT(title: sectionInput.sectionTitle, size: .medium)
-        titleView.titleLabel.font = .KorFont(style: .bold, size: 16)
-        titleView.rightButton.isHidden = true
-        let topView = UIView()
-        containerView.backgroundColor = .systemBackground
-        topView.backgroundColor = .g50
-
-        containerView.addSubview(topView)
-        topView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
-            make.height.equalTo(Constants.spaceGuide.small100)
-        }
-        if sectionInput.sectionTitle != nil {
-            containerView.addSubview(titleView)
-            titleView.snp.makeConstraints { make in
-                make.leading.trailing.equalToSuperview().inset(20)
-                make.top.equalTo(topView.snp.bottom).offset(Constants.spaceGuide.small400)
-                make.bottom.equalToSuperview().inset(Constants.spaceGuide.small400)
-            }
-        } else {
-            topView.snp.makeConstraints { make in
-                make.bottom.equalToSuperview().inset(Constants.spaceGuide.small400)
-            }
-        }
-        return containerView
-    }
-    
-    func sectionOutput() -> Output {
-        return Output()
-    }
-    
-    func makeFooterView() -> UIView? {
-        return nil
-    }
-}
+import RxSwift
 
 final class MenuListCell: UITableViewCell {
     
@@ -88,7 +36,6 @@ final class MenuListCell: UITableViewCell {
     // MARK: - init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setUp()
         setUpConstraints()
     }
     
@@ -99,9 +46,6 @@ final class MenuListCell: UITableViewCell {
 
 // MARK: - SetUp
 private extension MenuListCell {
-    func setUp() {
-        
-    }
     
     func setUpConstraints() {
         contentView.addSubview(contentStackView)
@@ -122,13 +66,11 @@ private extension MenuListCell {
     }
 }
 
-// MARK: - Methods
+// MARK: - Cellable
 extension MenuListCell: Cellable {
     
     struct Output {
-        
     }
-    
     
     struct Input {
         var title: String?

--- a/PopPool/PopPool/Presentation/Common/Interfaces/TableViewSectionable.swift
+++ b/PopPool/PopPool/Presentation/Common/Interfaces/TableViewSectionable.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RxSwift
 
 protocol TableViewSectionable: Inputable, Outputable {
     associatedtype CellType: Cellable, UITableViewCell
@@ -16,12 +17,15 @@ protocol TableViewSectionable: Inputable, Outputable {
     // Section의 Cell에 주입할 Input 배열
     var sectionCellInputList: [CellType.Input] { get set }
     
+    // Cell의 Output PublishSubject
+    var sectionCellOutput: PublishSubject<(CellType.Output, IndexPath)> { get set }
+    
     /// Section의 Cell을 Input을 주입한 상태로 리턴하는 메서드
     /// - Parameters:
     ///   - tableView: 테이블 뷰
     ///   - indexPath: indexPath
     /// - Returns: Section Cell
-    func getCell(tableView: UITableView, indexPath: IndexPath) -> CellType
+    mutating func getCell(tableView: UITableView, indexPath: IndexPath) -> CellType
     
     /// HeaderView를 생성하는 메서드
     /// - Returns: HeaderView
@@ -34,15 +38,15 @@ protocol TableViewSectionable: Inputable, Outputable {
     /// Header와 Footer의 Output을 리턴하는 메서드
     /// - Returns: Header, Footer Output
     mutating func sectionOutput() -> Output
-
 }
 
 extension TableViewSectionable {
-    func getCell(tableView: UITableView, indexPath: IndexPath) -> CellType {
+    mutating func getCell(tableView: UITableView, indexPath: IndexPath) -> CellType {
         tableView.register(CellType.self, forCellReuseIdentifier: CellType.identifier)
         let cell = tableView.dequeueReusableCell(withIdentifier: CellType.identifier, for: indexPath) as! CellType
         let input = sectionCellInputList[indexPath.row]
         cell.injectionWith(input: input)
+        self.sectionCellOutput.onNext((cell.getOutput(), indexPath))
         return cell
     }
 }

--- a/PopPool/PopPool/Presentation/Scene/MyPage/MyPageMainVM.swift
+++ b/PopPool/PopPool/Presentation/Scene/MyPage/MyPageMainVM.swift
@@ -47,7 +47,14 @@ final class MyPageMainVM: ViewModelable {
     private var myCommentSection = MyCommentCircleListCellSection(
         sectionInput: .init(sectionTitle: "내 코멘트"),
         sectionCellInputList: [
-            .init()
+            .init(cellInputList: [
+                .init(title: "팝업스토어1", isActive: true, image: UIImage(systemName: "person")),
+                .init(title: "팝업스토어2", isActive: false, image: UIImage(systemName: "person")),
+                .init(title: "팝업스토어3", isActive: false, image: UIImage(systemName: "person")),
+                .init(title: "팝업스토어4", isActive: false, image: UIImage(systemName: "person")),
+                .init(title: "팝업스토어5", isActive: false, image: UIImage(systemName: "person")),
+                .init(title: "팝업스토어6", isActive: false, image: UIImage(systemName: "person")),
+            ])
         ])
     // 일반 Section
     private var normalSection = MenuListCellSection(
@@ -82,6 +89,15 @@ final class MyPageMainVM: ViewModelable {
                 print("MyComment section Button Tapped")
             }
             .disposed(by: disposeBag)
+        
+        myCommentSection.sectionCellOutput.subscribe { (output, indexPath) in
+            output.didSelectCell.subscribe { cellIndexPath in
+                print(indexPath,cellIndexPath)
+            }
+            .disposed(by: self.disposeBag)
+        }
+        .disposed(by: disposeBag)
+        
         return Output()
     }
 }


### PR DESCRIPTION
## Description
- 내 코멘트 Cell 개발,
- TableViewSectionable Cell Output 헨들링 추가
- CellSection 파일들 분리
## Example
```
    // MARK: - transform
    func transform(input: Input) -> Output {

        // section Output 처리
        myCommentSection.sectionOutput().didTapRightButton
            .subscribe { _ in
                print("MyComment section Button Tapped")
            }
            .disposed(by: disposeBag)

        // Cell Output 처리
        // Cell의 Output과 indexPath를 함께 전달합니다.
        myCommentSection.sectionCellOutput.subscribe { (output, indexPath) in
            output.didSelectCell.subscribe { cellIndexPath in
                print(indexPath,cellIndexPath)
            }
            .disposed(by: self.disposeBag)
        }
        .disposed(by: disposeBag)
        
        return Output()
    }
```
- MyPage 작업 상황
![image](https://github.com/user-attachments/assets/cc003a3d-9797-4dab-9296-574872cc33ff)
