### PR TITLE
[MERGE]: ✅ SignUp API Connect

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		08E23A4E2C478870004B77B6 /* SignUpUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A4D2C478870004B77B6 /* SignUpUseCaseImpl.swift */; };
 		08E23A502C478900004B77B6 /* SignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A4F2C478900004B77B6 /* SignUpUseCase.swift */; };
 		08E23A532C4A2351004B77B6 /* InterestSelectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A522C4A2351004B77B6 /* InterestSelectedView.swift */; };
+		08E23A552C4CBC42004B77B6 /* RequestEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A542C4CBC42004B77B6 /* RequestEndPoint.swift */; };
 		08F49DDB2C200528002D5202 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DDA2C200528002D5202 /* AuthService.swift */; };
 		08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE92C231CFC002D5202 /* LoginResponse.swift */; };
 		08F49DEC2C231D13002D5202 /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */; };
@@ -239,6 +240,7 @@
 		08E23A4D2C478870004B77B6 /* SignUpUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUseCaseImpl.swift; sourceTree = "<group>"; };
 		08E23A4F2C478900004B77B6 /* SignUpUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUseCase.swift; sourceTree = "<group>"; };
 		08E23A522C4A2351004B77B6 /* InterestSelectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectedView.swift; sourceTree = "<group>"; };
+		08E23A542C4CBC42004B77B6 /* RequestEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestEndPoint.swift; sourceTree = "<group>"; };
 		08F49DDA2C200528002D5202 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		08F49DE92C231CFC002D5202 /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
 		08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDTO.swift; sourceTree = "<group>"; };
@@ -921,6 +923,7 @@
 		BDF3B2BC2C0BFC9900B079C5 /* EndPoint */ = {
 			isa = PBXGroup;
 			children = (
+				08E23A542C4CBC42004B77B6 /* RequestEndPoint.swift */,
 				BDD3351F2C0B6ACA002C2295 /* EndPoint.swift */,
 				BDF3B2A92C0BE23D00B079C5 /* Requestable.swift */,
 				BDF3B2C02C0C318E00B079C5 /* Responsable.swift */,
@@ -1185,6 +1188,7 @@
 				089D191D2C36B16D000435D9 /* MyPageMainVC.swift in Sources */,
 				BDC622B72C229517009411AE /* UserdefaultRepositoryImpl.swift in Sources */,
 				BDFA49242C342B3600D3C1FB /* UIView+.swift in Sources */,
+				08E23A552C4CBC42004B77B6 /* RequestEndPoint.swift in Sources */,
 				BD353B4B2C2D3D7D0004659D /* LoginVM.swift in Sources */,
 				087346132C0AAD2900534FFA /* SceneDelegate.swift in Sources */,
 				08C813FB2C2F2809009239FE /* SignUpRequestDTO.swift in Sources */,

--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		08E23A502C478900004B77B6 /* SignUpUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A4F2C478900004B77B6 /* SignUpUseCase.swift */; };
 		08E23A532C4A2351004B77B6 /* InterestSelectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A522C4A2351004B77B6 /* InterestSelectedView.swift */; };
 		08E23A552C4CBC42004B77B6 /* RequestEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A542C4CBC42004B77B6 /* RequestEndPoint.swift */; };
+		08E23A572C4D3450004B77B6 /* RequestTokenInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E23A562C4D3450004B77B6 /* RequestTokenInterceptor.swift */; };
 		08F49DDB2C200528002D5202 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DDA2C200528002D5202 /* AuthService.swift */; };
 		08F49DEA2C231CFC002D5202 /* LoginResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DE92C231CFC002D5202 /* LoginResponse.swift */; };
 		08F49DEC2C231D13002D5202 /* LoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */; };
@@ -241,6 +242,7 @@
 		08E23A4F2C478900004B77B6 /* SignUpUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpUseCase.swift; sourceTree = "<group>"; };
 		08E23A522C4A2351004B77B6 /* InterestSelectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectedView.swift; sourceTree = "<group>"; };
 		08E23A542C4CBC42004B77B6 /* RequestEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestEndPoint.swift; sourceTree = "<group>"; };
+		08E23A562C4D3450004B77B6 /* RequestTokenInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTokenInterceptor.swift; sourceTree = "<group>"; };
 		08F49DDA2C200528002D5202 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		08F49DE92C231CFC002D5202 /* LoginResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponse.swift; sourceTree = "<group>"; };
 		08F49DEB2C231D13002D5202 /* LoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDTO.swift; sourceTree = "<group>"; };
@@ -611,6 +613,7 @@
 			isa = PBXGroup;
 			children = (
 				08B183AD2C3D2601006C34BB /* TokenInterceptor.swift */,
+				08E23A562C4D3450004B77B6 /* RequestTokenInterceptor.swift */,
 			);
 			path = Interceptor;
 			sourceTree = "<group>";
@@ -1164,6 +1167,7 @@
 				08B183C92C443948006C34BB /* TableViewSectionable.swift in Sources */,
 				08B183BF2C43BEA6006C34BB /* MyCommentCircleListCell.swift in Sources */,
 				08C813DB2C2D3A58009239FE /* LargeChipCell.swift in Sources */,
+				08E23A572C4D3450004B77B6 /* RequestTokenInterceptor.swift in Sources */,
 				089D19002C30307A000435D9 /* ValidationTextFieldCPNT.swift in Sources */,
 				08B183AE2C3D2601006C34BB /* TokenInterceptor.swift in Sources */,
 				08E23A532C4A2351004B77B6 /* InterestSelectedView.swift in Sources */,

--- a/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hackiftekhar/IQKeyboardManager.git",
       "state" : {
-        "revision" : "19e111f9246b3407fe0c334dc78fa890c40d8c67",
-        "version" : "7.0.3"
+        "revision" : "fa9b2bac94b3fabe2d6ca7c74b269d4e8c355111",
+        "version" : "7.1.1"
       }
     },
     {

--- a/PopPool/PopPool/Data/Network/PopPoolNetwork/PopPoolAPIEndPoint.swift
+++ b/PopPool/PopPool/Data/Network/PopPoolNetwork/PopPoolAPIEndPoint.swift
@@ -16,7 +16,7 @@ struct PopPoolAPIEndPoint {
     /// - Returns: 로그인 응답 DTO를 반환하는 Endpoint
     static func tryLogin(with userCredential: Encodable, path: String) -> Endpoint<LoginResponseDTO> {
         return Endpoint(
-            baseURL: "http://localhost:8080",
+            baseURL: Secrets.popPoolBaseUrl.rawValue,
             path: "/auth/\(path)",
             method: .post,
             bodyParameters: userCredential
@@ -25,7 +25,7 @@ struct PopPoolAPIEndPoint {
     
     static func checkNickName(with request: CheckNickNameRequestDTO) -> Endpoint<Bool> {
         return Endpoint(
-            baseURL: "http://localhost:8080",
+            baseURL: Secrets.popPoolBaseUrl.rawValue,
             path: "/signup/check-nickname",
             method: .get,
             queryParameters: request
@@ -34,7 +34,7 @@ struct PopPoolAPIEndPoint {
     
     static func fetchInterestList() -> Endpoint<InterestListResponseDTO> {
         return Endpoint(
-            baseURL: "http://localhost:8080",
+            baseURL: Secrets.popPoolBaseUrl.rawValue,
             path: "/signup/interests",
             method: .get
         )
@@ -42,7 +42,7 @@ struct PopPoolAPIEndPoint {
     
     static func trySignUp(with request: SignUpRequestDTO) -> RequestEndpoint {
         return RequestEndpoint(
-            baseURL: "http://localhost:8080",
+            baseURL: Secrets.popPoolBaseUrl.rawValue,
             path: "/signup",
             method: .post,
             bodyParameters: request

--- a/PopPool/PopPool/Data/Network/PopPoolNetwork/PopPoolAPIEndPoint.swift
+++ b/PopPool/PopPool/Data/Network/PopPoolNetwork/PopPoolAPIEndPoint.swift
@@ -39,4 +39,13 @@ struct PopPoolAPIEndPoint {
             method: .get
         )
     }
+    
+    static func trySignUp(with request: SignUpRequestDTO) -> RequestEndpoint {
+        return RequestEndpoint(
+            baseURL: "http://localhost:8080",
+            path: "/signup",
+            method: .post,
+            bodyParameters: request
+        )
+    }
 }

--- a/PopPool/PopPool/Data/Network/PopPoolNetwork/SignUpDTO/SignUpRequestDTO.swift
+++ b/PopPool/PopPool/Data/Network/PopPoolNetwork/SignUpDTO/SignUpRequestDTO.swift
@@ -14,7 +14,7 @@ struct SignUpRequestDTO: Encodable {
     var age: Int32
     var socialEmail: String?
     var socialType: String
-    var interests: [String]
+    var interests: [Int]
 }
 
 

--- a/PopPool/PopPool/Data/Network/PopPoolNetwork/SignUpDTO/SignUpRequestDTO.swift
+++ b/PopPool/PopPool/Data/Network/PopPoolNetwork/SignUpDTO/SignUpRequestDTO.swift
@@ -12,6 +12,7 @@ struct SignUpRequestDTO: Encodable {
     var nickName: String
     var gender: String
     var age: Int32
+    var socialEmail: String
     var socialType: String
     var interests: [String]
 }

--- a/PopPool/PopPool/Data/Network/PopPoolNetwork/SignUpDTO/SignUpRequestDTO.swift
+++ b/PopPool/PopPool/Data/Network/PopPoolNetwork/SignUpDTO/SignUpRequestDTO.swift
@@ -12,7 +12,7 @@ struct SignUpRequestDTO: Encodable {
     var nickName: String
     var gender: String
     var age: Int32
-    var socialEmail: String
+    var socialEmail: String?
     var socialType: String
     var interests: [String]
 }

--- a/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
+++ b/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
@@ -23,4 +23,25 @@ final class SignUpRepositoryImpl: SignUpRepository {
             return responseDTO.interestResponseList.map({ $0.toDomain() })
         }
     }
+    
+    func trySignUp(
+        userId: String,
+        nickName: String,
+        gender: String,
+        age: Int32,
+        socialEmail: String,
+        socialType: String,
+        interests: [String]
+    ) -> Completable {
+        let endPoint = PopPoolAPIEndPoint.trySignUp(with: .init(
+            userId: userId,
+            nickName: nickName,
+            gender: gender,
+            age: age,
+            socialEmail: socialEmail,
+            socialType: socialType,
+            interests: interests)
+        )
+        return provider.request(with: endPoint, interceptor: TokenInterceptor())
+    }
 }

--- a/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
+++ b/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
@@ -31,7 +31,7 @@ final class SignUpRepositoryImpl: SignUpRepository {
         age: Int32,
         socialEmail: String?,
         socialType: String,
-        interests: [String]
+        interests: [Int]
     ) -> Completable {
         let endPoint = PopPoolAPIEndPoint.trySignUp(with: .init(
             userId: userId,

--- a/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
+++ b/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
@@ -29,7 +29,7 @@ final class SignUpRepositoryImpl: SignUpRepository {
         nickName: String,
         gender: String,
         age: Int32,
-        socialEmail: String,
+        socialEmail: String?,
         socialType: String,
         interests: [String]
     ) -> Completable {

--- a/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
+++ b/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryImpl.swift
@@ -42,6 +42,6 @@ final class SignUpRepositoryImpl: SignUpRepository {
             socialType: socialType,
             interests: interests)
         )
-        return provider.request(with: endPoint, interceptor: TokenInterceptor())
+        return provider.request(with: endPoint, interceptor: RequestTokenInterceptor())
     }
 }

--- a/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryTest.swift
+++ b/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryTest.swift
@@ -40,7 +40,7 @@ final class SignUpRepositoryTest: SignUpRepository {
         age: Int32,
         socialEmail: String?,
         socialType: String,
-        interests: [String]
+        interests: [Int]
     ) -> Completable {
         return Completable.create { observer in
             observer(.completed)

--- a/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryTest.swift
+++ b/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryTest.swift
@@ -38,7 +38,7 @@ final class SignUpRepositoryTest: SignUpRepository {
         nickName: String,
         gender: String,
         age: Int32,
-        socialEmail: String, 
+        socialEmail: String?,
         socialType: String,
         interests: [String]
     ) -> Completable {

--- a/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryTest.swift
+++ b/PopPool/PopPool/Data/Repositories/SignUpRepository/SignUpRepositoryTest.swift
@@ -32,4 +32,19 @@ final class SignUpRepositoryTest: SignUpRepository {
         ]
         return Observable.just(interest)
     }
+    
+    func trySignUp(
+        userId: String,
+        nickName: String,
+        gender: String,
+        age: Int32,
+        socialEmail: String, 
+        socialType: String,
+        interests: [String]
+    ) -> Completable {
+        return Completable.create { observer in
+            observer(.completed)
+            return Disposables.create()
+        }
+    }
 }

--- a/PopPool/PopPool/Domain/Interfaces/AuthService.swift
+++ b/PopPool/PopPool/Domain/Interfaces/AuthService.swift
@@ -8,9 +8,16 @@
 import Foundation
 import RxSwift
 
-protocol AuthService: Responsable, AnyObject {
+protocol AuthService: AnyObject {
+    associatedtype Credential: Encodable
     
     /// 사용자 자격 증명을 가져오는 함수
     /// - Returns: Response 형태의 사용자 자격 증명
-    func fetchUserCredential() -> Observable<Encodable>
+    func fetchUserCredential() -> Observable<AuthServiceResponse>
+}
+
+struct AuthServiceResponse {
+    var credential: Encodable
+    var socialType: String
+    var userEmail: String
 }

--- a/PopPool/PopPool/Domain/Interfaces/AuthService.swift
+++ b/PopPool/PopPool/Domain/Interfaces/AuthService.swift
@@ -19,5 +19,5 @@ protocol AuthService: AnyObject {
 struct AuthServiceResponse {
     var credential: Encodable
     var socialType: String
-    var userEmail: String
+    var userEmail: String?
 }

--- a/PopPool/PopPool/Domain/Interfaces/FetchSocialCredentialUseCase.swift
+++ b/PopPool/PopPool/Domain/Interfaces/FetchSocialCredentialUseCase.swift
@@ -15,5 +15,5 @@ protocol FetchSocialCredentialUseCase {
     
     /// 사용자의 자격 증명을 가져오는 메서드입니다.
     /// - Returns: 인증 서비스에서 반환하는 응답을 포함하는 Observable 객체
-    func execute() -> Observable<Encodable>
+    func execute() -> Observable<AuthServiceResponse>
 }

--- a/PopPool/PopPool/Domain/Interfaces/SignUpRepository.swift
+++ b/PopPool/PopPool/Domain/Interfaces/SignUpRepository.swift
@@ -37,7 +37,7 @@ protocol SignUpRepository{
         nickName: String,
         gender: String,
         age: Int32,
-        socialEmail: String,
+        socialEmail: String?,
         socialType: String,
         interests: [String]
     ) -> Completable

--- a/PopPool/PopPool/Domain/Interfaces/SignUpRepository.swift
+++ b/PopPool/PopPool/Domain/Interfaces/SignUpRepository.swift
@@ -39,6 +39,6 @@ protocol SignUpRepository{
         age: Int32,
         socialEmail: String?,
         socialType: String,
-        interests: [String]
+        interests: [Int]
     ) -> Completable
 }

--- a/PopPool/PopPool/Domain/Interfaces/SignUpRepository.swift
+++ b/PopPool/PopPool/Domain/Interfaces/SignUpRepository.swift
@@ -21,4 +21,24 @@ protocol SignUpRepository{
     /// - Parameter credential: 인증 정보
     /// - Returns: 관심사 리스트를 나타내는 Observable<[Interest]>
     func fetchInterestList() -> Observable<[Interest]>
+    
+    /// 회원가입을 시도하는 메서드
+    /// - Parameters:
+    ///   - userId: 유저 아이디
+    ///   - nickName: 유저 닉네임
+    ///   - gender: 유저 성별
+    ///   - age: 유저 나이
+    ///   - socialEmail: 유저 소셜로그인 이메일
+    ///   - socialType: 유저 소셜로그인 타입
+    ///   - interests: 유저 관심사 목록
+    /// - Returns: 회원가입 성공여부를 리턴하는 observer
+    func trySignUp(
+        userId: String,
+        nickName: String,
+        gender: String,
+        age: Int32,
+        socialEmail: String,
+        socialType: String,
+        interests: [String]
+    ) -> Completable
 }

--- a/PopPool/PopPool/Domain/Interfaces/SignUpUseCase.swift
+++ b/PopPool/PopPool/Domain/Interfaces/SignUpUseCase.swift
@@ -28,7 +28,7 @@ protocol SignUpUseCase {
         age: Int32,
         socialEmail: String?,
         socialType: String,
-        interests: [String]
+        interests: [Int]
     ) -> Completable
     
     /// 닉네임 중복 여부를 확인하는 메서드

--- a/PopPool/PopPool/Domain/Interfaces/SignUpUseCase.swift
+++ b/PopPool/PopPool/Domain/Interfaces/SignUpUseCase.swift
@@ -11,6 +11,26 @@ import RxSwift
 protocol SignUpUseCase {
     var repository: SignUpRepository { get set }
     
+    /// 회원가입을 시도하는 메서드
+    /// - Parameters:
+    ///   - userId: 유저 아이디
+    ///   - nickName: 유저 닉네임
+    ///   - gender: 유저 성별
+    ///   - age: 유저 나이
+    ///   - socialEmail: 유저 소셜로그인 이메일
+    ///   - socialType: 유저 소셜로그인 타입
+    ///   - interests: 유저 관심사 목록
+    /// - Returns: 회원가입 성공여부를 리턴하는 observer
+    func trySignUp(
+        userId: String,
+        nickName: String,
+        gender: String,
+        age: Int32,
+        socialEmail: String?,
+        socialType: String,
+        interests: [String]
+    ) -> Completable
+    
     /// 닉네임 중복 여부를 확인하는 메서드
     /// - Parameters:
     ///   - nickName: 확인할 닉네임
@@ -22,4 +42,5 @@ protocol SignUpUseCase {
     /// - Parameter credential: 인증 정보
     /// - Returns: 관심사 리스트를 나타내는 Observable<[Interest]>
     func fetchInterestList() -> Observable<[Interest]>
+
 }

--- a/PopPool/PopPool/Domain/UseCase/FetchSocialCredentialUseCaseImpl.swift
+++ b/PopPool/PopPool/Domain/UseCase/FetchSocialCredentialUseCaseImpl.swift
@@ -16,7 +16,7 @@ final class FetchSocialCredentialUseCaseImpl: FetchSocialCredentialUseCase {
         self.service = service
     }
 
-    func execute() -> Observable<Encodable> {
+    func execute() -> Observable<AuthServiceResponse> {
         return service.fetchUserCredential()
     }
 }

--- a/PopPool/PopPool/Domain/UseCase/SignUpUseCaseImpl.swift
+++ b/PopPool/PopPool/Domain/UseCase/SignUpUseCaseImpl.swift
@@ -14,7 +14,25 @@ final class SignUpUseCaseImpl: SignUpUseCase {
     init(repository: SignUpRepository) {
         self.repository = repository
     }
-
+    func trySignUp(
+        userId: String,
+        nickName: String,
+        gender: String,
+        age: Int32,
+        socialEmail: String?,
+        socialType: String,
+        interests: [String]
+    ) -> Completable {
+        return repository.trySignUp(
+            userId: userId,
+            nickName: nickName,
+            gender: gender,
+            age: age,
+            socialEmail: socialEmail,
+            socialType: socialType,
+            interests: interests
+        )
+    }
     func checkNickName(nickName: String) -> Observable<Bool> {
         return repository.checkNickName(nickName: nickName)
     }

--- a/PopPool/PopPool/Domain/UseCase/SignUpUseCaseImpl.swift
+++ b/PopPool/PopPool/Domain/UseCase/SignUpUseCaseImpl.swift
@@ -21,7 +21,7 @@ final class SignUpUseCaseImpl: SignUpUseCase {
         age: Int32,
         socialEmail: String?,
         socialType: String,
-        interests: [String]
+        interests: [Int]
     ) -> Completable {
         return repository.trySignUp(
             userId: userId,

--- a/PopPool/PopPool/Infrastructure/Network/Common/NetworkError.swift
+++ b/PopPool/PopPool/Infrastructure/Network/Common/NetworkError.swift
@@ -17,6 +17,7 @@ enum NetworkError: Error {
     case parsing(Error)
     case emptyData
     case decodeError
+    case serverError(String)
 
     var errorDescription: String? {
         switch self {
@@ -36,6 +37,8 @@ enum NetworkError: Error {
             return "data가 비어있습니다."
         case .decodeError:
             return "decode 에러가 발생했습니다."
+        case .serverError(let message):
+            return message
         }
     }
 }

--- a/PopPool/PopPool/Infrastructure/Network/EndPoint/RequestEndPoint.swift
+++ b/PopPool/PopPool/Infrastructure/Network/EndPoint/RequestEndPoint.swift
@@ -1,0 +1,35 @@
+//
+//  RequestEndPoint.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 7/21/24.
+//
+
+import Foundation
+import Alamofire
+
+class RequestEndpoint: Requestable {
+    var baseURL: String
+    var path: String
+    var method: HTTPMethod
+    var queryParameters: Encodable?
+    var bodyParameters: Encodable?
+    var headers: [String: String]?
+    var sampleData: Data?
+
+    init(baseURL: String,
+         path: String = "",
+         method: HTTPMethod = .get,
+         queryParameters: Encodable? = nil,
+         bodyParameters: Encodable? = nil,
+         headers: [String: String]? = [:],
+         sampleData: Data? = nil) {
+        self.baseURL = baseURL
+        self.path = path
+        self.method = method
+        self.queryParameters = queryParameters
+        self.bodyParameters = bodyParameters
+        self.headers = headers
+        self.sampleData = sampleData
+    }
+}

--- a/PopPool/PopPool/Infrastructure/Network/Interceptor/RequestTokenInterceptor.swift
+++ b/PopPool/PopPool/Infrastructure/Network/Interceptor/RequestTokenInterceptor.swift
@@ -1,0 +1,32 @@
+//
+//  RequestTokenInterceptor.swift
+//  PopPool
+//
+//  Created by SeoJunYoung on 7/21/24.
+//
+
+import Foundation
+import Alamofire
+import RxSwift
+
+final class RequestTokenInterceptor: RequestInterceptor {
+    
+    private var disposeBag = DisposeBag()
+    
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, any Error>) -> Void) {
+        var urlRequest = urlRequest
+
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let keyChainService = KeyChainServiceImpl()
+        
+        // Request Header에 Token 추가
+        keyChainService.fetchToken(type: .accessToken)
+            .subscribe { accessToken in
+                urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+                completion(.success(urlRequest))
+            } onFailure: { error in
+                completion(.failure(error))
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/PopPool/PopPool/Infrastructure/Network/Provider/Provider.swift
+++ b/PopPool/PopPool/Infrastructure/Network/Provider/Provider.swift
@@ -100,11 +100,17 @@ class ProviderImpl: Provider {
                     .validate()
                     .response { response in
                         switch response.result {
-                        case .success(let data):
+                        case .success:
                             observer(.completed)
                         case .failure(let error):
-                            observer(.error(error))
-                            print(error.localizedDescription)
+                            if let data = response.data {
+                                if let errorMessage = String(data: data, encoding: .utf8) {
+                                    print(errorMessage)
+                                    observer(.error(NetworkError.serverError(errorMessage)))
+                                }
+                            } else {
+                                observer(.error(error))
+                            }
                         }
                     }
             } catch {

--- a/PopPool/PopPool/Infrastructure/Network/Provider/Provider.swift
+++ b/PopPool/PopPool/Infrastructure/Network/Provider/Provider.swift
@@ -66,7 +66,8 @@ class ProviderImpl: Provider {
         return Observable.create { observer in
             
             do {
-                let urlRequest = try endpoint.getUrlRequest()
+                var urlRequest = try endpoint.getUrlRequest()
+                urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
                 AF.request(urlRequest)
                     .validate()
                     .responseData { response in
@@ -100,7 +101,13 @@ class ProviderImpl: Provider {
                     .responseData { response in
                         switch response.result {
                         case .success(let data):
-                            observer(.completed)
+                            if response.response?.statusCode == 200 {
+                                observer(.completed)
+                            } else {
+                                if let statusCode = response.response?.statusCode {
+                                    observer(.error(NetworkError.invalidHttpStatusCode(statusCode)))
+                                }
+                            }
                         case .failure(let error):
                             observer(.error(error))
                         }

--- a/PopPool/PopPool/Infrastructure/Network/Provider/Provider.swift
+++ b/PopPool/PopPool/Infrastructure/Network/Provider/Provider.swift
@@ -98,18 +98,13 @@ class ProviderImpl: Provider {
                 let urlRequest = try request.getUrlRequest()
                 AF.request(urlRequest, interceptor: interceptor)
                     .validate()
-                    .responseData { response in
+                    .response { response in
                         switch response.result {
                         case .success(let data):
-                            if response.response?.statusCode == 200 {
-                                observer(.completed)
-                            } else {
-                                if let statusCode = response.response?.statusCode {
-                                    observer(.error(NetworkError.invalidHttpStatusCode(statusCode)))
-                                }
-                            }
+                            observer(.completed)
                         case .failure(let error):
                             observer(.error(error))
+                            print(error.localizedDescription)
                         }
                     }
             } catch {

--- a/PopPool/PopPool/Infrastructure/Service/AuthService/Services/AppleAuthServiceImpl.swift
+++ b/PopPool/PopPool/Infrastructure/Service/AuthService/Services/AppleAuthServiceImpl.swift
@@ -17,13 +17,13 @@ final class AppleAuthServiceImpl: NSObject, AuthService  {
     }
     
     // 사용자 자격 증명 정보를 방출할 subject
-    private var userCredentialObserver = PublishSubject<Credential>()
-    
     private var authServiceResponse: PublishSubject<AuthServiceResponse> = .init()
     
     func fetchUserCredential() -> Observable<AuthServiceResponse> {
         performRequest()
-        return authServiceResponse
+        return authServiceResponse.map { response in
+            return AuthServiceResponse(credential: response.credential, socialType: response.socialType, userEmail: response.userEmail)
+        }
     }
     
     // Apple 인증 요청을 수행하는 함수
@@ -41,12 +41,16 @@ final class AppleAuthServiceImpl: NSObject, AuthService  {
 }
 
 extension AppleAuthServiceImpl: ASAuthorizationControllerPresentationContextProviding,
-                                ASAuthorizationControllerDelegate 
+                                ASAuthorizationControllerDelegate
 {
     
     // 인증 컨트롤러의 프레젠테이션 앵커를 반환하는 함수
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        guard let window = UIApplication.shared.windows.first else { return UIWindow() }
+        let scenes = UIApplication.shared.connectedScenes
+        let windowSecne = scenes.first as? UIWindowScene
+        guard let window = windowSecne?.windows.first else {
+            return UIWindow()
+        }
         return window
     }
     
@@ -55,25 +59,22 @@ extension AppleAuthServiceImpl: ASAuthorizationControllerPresentationContextProv
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             
-            guard let authorizationCode = appleIDCredential.authorizationCode,
-                  let idToken = appleIDCredential.identityToken,
-                  let email = appleIDCredential.email
+            guard let idToken = appleIDCredential.identityToken
             else {
                 // 토큰이 없는 경우 오류 방출
-                userCredentialObserver.onError(AuthError.unknownError)
+                authServiceResponse.onError(AuthError.unknownError)
                 return
             }
             
-            guard let authorizationCode = String(data: authorizationCode, encoding: .utf8),
-                  let idToken = String(data: idToken, encoding: .utf8)
+            guard let idToken = String(data: idToken, encoding: .utf8) 
             else {
                 // 토큰이 없는 경우 오류 방출
-                userCredentialObserver.onError(AuthError.unknownError)
+                authServiceResponse.onError(AuthError.unknownError)
                 return
             }
             // 성공적으로 사용자 자격 증명을 방출
             let credential: Credential = .init(idToken: idToken)
-            authServiceResponse.onNext(.init(credential: credential, socialType: "APPLE", userEmail: email))
+            authServiceResponse.onNext(.init(credential: credential, socialType: "APPLE", userEmail: appleIDCredential.email))
         default:
             break
         }
@@ -81,6 +82,6 @@ extension AppleAuthServiceImpl: ASAuthorizationControllerPresentationContextProv
     
     // 인증 실패 시 호출되는 함수
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        userCredentialObserver.onError(error)
+        authServiceResponse.onError(error)
     }
 }

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVC.swift
@@ -142,9 +142,8 @@ private extension LoginVC {
         
         output.moveToSignUpVC
             .withUnretained(self)
-            .subscribe { (owner, socialType) in
-                let vm = SignUpVM()
-                let vc = SignUpVC(viewModel: vm)
+            .subscribe { (owner, viewModel) in
+                let vc = SignUpVC(viewModel: viewModel)
                 owner.navigationController?.pushViewController(vc, animated: true)
             }
             .disposed(by: disposeBag)

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVM.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVM.swift
@@ -114,7 +114,12 @@ final class LoginVM: ViewModelable {
 
                         // 등록된 유저인지를 분기하여 이벤트 전달
                         if loginResponse.registeredUser {
-                            moveToHomeVCSubject.onNext(loginResponse)
+                            let vm = SignUpVM()
+                            vm.signUpData.socialType = response.socialType
+                            vm.signUpData.socialEmail = response.userEmail
+                            vm.signUpData.userId = loginResponse.userId
+                            moveToSignUpVCSubject.onNext(vm)
+//                            moveToHomeVCSubject.onNext(loginResponse)
                         } else {
                             let vm = SignUpVM()
                             vm.signUpData.socialType = response.socialType

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVM.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/Login/LoginVM.swift
@@ -114,12 +114,7 @@ final class LoginVM: ViewModelable {
 
                         // 등록된 유저인지를 분기하여 이벤트 전달
                         if loginResponse.registeredUser {
-                            let vm = SignUpVM()
-                            vm.signUpData.socialType = response.socialType
-                            vm.signUpData.socialEmail = response.userEmail
-                            vm.signUpData.userId = loginResponse.userId
-                            moveToSignUpVCSubject.onNext(vm)
-//                            moveToHomeVCSubject.onNext(loginResponse)
+                            moveToHomeVCSubject.onNext(loginResponse)
                         } else {
                             let vm = SignUpVM()
                             vm.signUpData.socialType = response.socialType

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
@@ -298,6 +298,16 @@ private extension SignUpVC {
                 owner.presentModalViewController(viewController: vc)
             }
             .disposed(by: disposeBag)
+        
+        output.step4_moveToSignUpCompleteVC
+            .withUnretained(self)
+            .subscribe { (owner, source) in
+                let nickName = source.0
+                let list = source.1
+                let vc = SignUpCompletedVC(nickname: nickName, tags: list)
+                owner.navigationController?.pushViewController(vc, animated: true)
+            }
+            .disposed(by: disposeBag)
     }
 }
 // MARK: - Methods

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVC.swift
@@ -179,9 +179,13 @@ private extension SignUpVC {
             tap_step3_primaryButton: step3_primaryButton.rx.tap,
             tap_step3_secondaryButton: step3_secondaryButton.rx.tap,
             event_step3_didChangeInterestList: step3_ContentView.fetchSelectedList(),
-            event_step4_didSelectGender: step4_ContentView.genderSegmentedControl.rx.selectedSegmentIndex,
+            event_step4_didSelectGender: step4_ContentView.genderSegmentedControl.rx.selectedSegmentIndex.map({ [weak self] index in
+                guard let self = self else { return "" }
+                return self.step4_ContentView.genderList[index]
+            }),
             tap_step4_ageButton: step4_ContentView.ageButton.rx.tap,
             tap_step4_secondaryButton: step4_secondaryButton.rx.tap,
+            tap_step4_primaryButton: step4_primaryButton.rx.tap,
             event_step4_didSelectAge: ageRelayObserver
         )
         // MARK: - Output

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/SignUpVM.swift
@@ -19,7 +19,7 @@ final class SignUpVM: ViewModelable {
         var age: Int32
         var socialEmail: String?
         var socialType: String
-        var interests: [String]
+        var interests: [Int]
     }
     
     /// 입력 이벤트
@@ -52,7 +52,7 @@ final class SignUpVM: ViewModelable {
         /// Sign Up Step3 secondary button  탭 이벤트
         var tap_step3_secondaryButton: ControlEvent<Void>
         /// 관심사 변경을 전달하는 Subject
-        var event_step3_didChangeInterestList: Observable<[String]>
+        var event_step3_didChangeInterestList: Observable<[Int]>
         
         // MARK: - Step 4 Input
         /// step 4 gender segmentedControl 이벤트
@@ -324,10 +324,11 @@ final class SignUpVM: ViewModelable {
                     interests: owner.signUpData.interests
                 )
                 .subscribe {
-                    step4_moveToSignUpCompleteVC.onNext((owner.signUpData.nickName, owner.signUpData.interests))
+                    step4_moveToSignUpCompleteVC.onNext((owner.signUpData.nickName, owner.signUpData.interests.map({ index in
+                        return fetchCategoryList.value[index]
+                    })))
                 } onError: { error in
                     ToastMSGManager.createToast(message: "SignUpError")
-                    print(error)
                 }
                 .disposed(by: owner.disposeBag)
 

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep3View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep3View.swift
@@ -89,11 +89,9 @@ extension SignUpStep3View {
     
     /// 선택된 리스트를 가져오는 메서드
     /// - Returns: 선택된 카테고리 리스트를 반환하는 옵저버블
-    func fetchSelectedList() -> Observable<[String]> {
+    func fetchSelectedList() -> Observable<[Int]> {
         return categoryCollectionView.selectedList.map { indexPathList in
-            return indexPathList.compactMap { indexPath in
-                return self.categoryCollectionView.categoryList.value[indexPath.row]
-            }
+            return indexPathList.map({ $0.row })
         }
     }
     

--- a/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep4View.swift
+++ b/PopPool/PopPool/Presentation/Scene/OnBoarding/SignUp/Views/SignUpStep4View.swift
@@ -35,9 +35,9 @@ final class SignUpStep4View: UIStackView {
         return label
     }()
     private let genderLabelBottomspacingView = UIView()
-    let genderSegmentedControl: SegmentedControlCPNT = SegmentedControlCPNT(
+    lazy var genderSegmentedControl: SegmentedControlCPNT = SegmentedControlCPNT(
         type: .base,
-        segments: ["남성", "여성", "선택안함"],
+        segments: self.genderList,
         selectedSegmentIndex: 2
     )
     private let genderSegmentedControlBottomSpacingView = UIView()
@@ -51,6 +51,8 @@ final class SignUpStep4View: UIStackView {
     private let ageLabelBottomSpacingView = UIView()
     let ageButton = SignUpAgeSelectedButton()
     private let bottomSpacingView = UIView()
+    
+    let genderList: [String] = ["남성", "여성", "선택안함"]
     
     // MARK: - init
     init() {

--- a/PopPool/PopPool/Resource/Info.plist
+++ b/PopPool/PopPool/Resource/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>GothicA1-Bold.ttf</string>


### PR DESCRIPTION
## Description
- Provider에 Request 전용 메서드를 생성하였습니다
- Request EndPoint를 이용하여 응답이 없는 요청을 생성합니다.
- RequestTokenInterceptor를 이용하여 retry를 하지 않는 요청을 보냅니다.
- SignUp 프로세스의 건너뛰기를 제외한 기능을 연결하였습니다.
- 개발시 테스트를 위해 임시로 HTTP URL 요청 허용을 처리하였습니다.
## Changes
- AuthService에서 Response 만 Encodable로 사용한 기존의 방식에서 Response의 제네릭 명을 Credential로 변경후 AuthSeriveResponse 타입에 종속시켜 사용합니다. 변경의 이유는 회원가입시 필요한 SocialType, UserEmail등을 포함한 리턴값을 사용하기 위하여 변경하였습니다.
- 특이사항: Apple 소셜로그인의 경우 단 한번의 초기 로그인에서만 유저에게 Email을 요청할 수 있습니다.
- 기존의 Interests관련 API는 문자열을 요청에 싣어 보내는 형식에서 스웨거 및 백엔드 개발자 분과 이야기하여 관심사의 키값에 해당하는 정수를 싣는 형태로 변경하였습니다.
