### PR TITLE
[MERGE]: ✅ List Menu CPNT, ListInfoCPNT 생성

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		BDA0B1342C2DD102007BDCA4 /* Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA0B1332C2DD102007BDCA4 /* Factory.swift */; };
 		BDA0B1372C2E622B007BDCA4 /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA0B1362C2E622B007BDCA4 /* ModalViewController.swift */; };
 		BDB682552C1C316000560E7B /* LocalDBRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB682542C1C316000560E7B /* LocalDBRepository.swift */; };
+		BDBE5E2F2C4E573200260FFC /* ListMenuCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBE5E2E2C4E573200260FFC /* ListMenuCPNT.swift */; };
 		BDC622B12C225817009411AE /* DatabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B02C225817009411AE /* DatabaseError.swift */; };
 		BDC622B52C2294D4009411AE /* SaveLocalUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B42C2294D4009411AE /* SaveLocalUseCaseImpl.swift */; };
 		BDC622B72C229517009411AE /* UserdefaultRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B62C229517009411AE /* UserdefaultRepositoryImpl.swift */; };
@@ -278,6 +279,7 @@
 		BDA0B1332C2DD102007BDCA4 /* Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Factory.swift; sourceTree = "<group>"; };
 		BDA0B1362C2E622B007BDCA4 /* ModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
 		BDB682542C1C316000560E7B /* LocalDBRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBRepository.swift; sourceTree = "<group>"; };
+		BDBE5E2E2C4E573200260FFC /* ListMenuCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListMenuCPNT.swift; sourceTree = "<group>"; };
 		BDC622B02C225817009411AE /* DatabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseError.swift; sourceTree = "<group>"; };
 		BDC622B42C2294D4009411AE /* SaveLocalUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveLocalUseCaseImpl.swift; sourceTree = "<group>"; };
 		BDC622B62C229517009411AE /* UserdefaultRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserdefaultRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -812,6 +814,7 @@
 				089D19122C3544DB000435D9 /* PickerCPNT.swift */,
 				089D19282C3BD318000435D9 /* ProfileCircleImageViewCPNT.swift */,
 				08B183C22C442113006C34BB /* ListTitleViewCPNT.swift */,
+				BDBE5E2E2C4E573200260FFC /* ListMenuCPNT.swift */,
 				08B183C42C4421D5006C34BB /* TextUnderBarButtonCPNT.swift */,
 			);
 			path = Components;
@@ -1226,6 +1229,7 @@
 				BD3C4C6D2C30C8AE0087917B /* HeaderViewCPNT.swift in Sources */,
 				BD353B472C2C13460004659D /* HeaderViewCPNT.swift in Sources */,
 				08A28CBA2C2AC44300DF7A90 /* SignUpVM.swift in Sources */,
+				BDBE5E2F2C4E573200260FFC /* ListMenuCPNT.swift in Sources */,
 				08C813E42C2E9FB0009239FE /* SignUpAgeSelectedButton.swift in Sources */,
 				08A28CAA2C27E16F00DF7A90 /* SignUpVC.swift in Sources */,
 				089D19022C3032EC000435D9 /* SignUpStep2View.swift in Sources */,

--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		BDA0B1372C2E622B007BDCA4 /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA0B1362C2E622B007BDCA4 /* ModalViewController.swift */; };
 		BDB682552C1C316000560E7B /* LocalDBRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB682542C1C316000560E7B /* LocalDBRepository.swift */; };
 		BDBE5E2F2C4E573200260FFC /* ListMenuCPNT.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBE5E2E2C4E573200260FFC /* ListMenuCPNT.swift */; };
+		BDBE5E372C4F8FD500260FFC /* ListInfoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBE5E362C4F8FD500260FFC /* ListInfoButton.swift */; };
 		BDC622B12C225817009411AE /* DatabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B02C225817009411AE /* DatabaseError.swift */; };
 		BDC622B52C2294D4009411AE /* SaveLocalUseCaseImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B42C2294D4009411AE /* SaveLocalUseCaseImpl.swift */; };
 		BDC622B72C229517009411AE /* UserdefaultRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC622B62C229517009411AE /* UserdefaultRepositoryImpl.swift */; };
@@ -280,6 +281,7 @@
 		BDA0B1362C2E622B007BDCA4 /* ModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
 		BDB682542C1C316000560E7B /* LocalDBRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDBRepository.swift; sourceTree = "<group>"; };
 		BDBE5E2E2C4E573200260FFC /* ListMenuCPNT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListMenuCPNT.swift; sourceTree = "<group>"; };
+		BDBE5E362C4F8FD500260FFC /* ListInfoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListInfoButton.swift; sourceTree = "<group>"; };
 		BDC622B02C225817009411AE /* DatabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseError.swift; sourceTree = "<group>"; };
 		BDC622B42C2294D4009411AE /* SaveLocalUseCaseImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveLocalUseCaseImpl.swift; sourceTree = "<group>"; };
 		BDC622B62C229517009411AE /* UserdefaultRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserdefaultRepositoryImpl.swift; sourceTree = "<group>"; };
@@ -815,6 +817,7 @@
 				089D19282C3BD318000435D9 /* ProfileCircleImageViewCPNT.swift */,
 				08B183C22C442113006C34BB /* ListTitleViewCPNT.swift */,
 				BDBE5E2E2C4E573200260FFC /* ListMenuCPNT.swift */,
+				BDBE5E362C4F8FD500260FFC /* ListInfoButton.swift */,
 				08B183C42C4421D5006C34BB /* TextUnderBarButtonCPNT.swift */,
 			);
 			path = Components;
@@ -1198,6 +1201,7 @@
 				087346562C0AEBD900534FFA /* AppDIContainer.swift in Sources */,
 				08F49DF22C23230C002D5202 /* AuthRepository.swift in Sources */,
 				089D191A2C368C73000435D9 /* SignUpCompletedVC.swift in Sources */,
+				BDBE5E372C4F8FD500260FFC /* ListInfoButton.swift in Sources */,
 				BDDF7D122C4A2AA8008F8EAC /* SignOutCompleteVC.swift in Sources */,
 				08B183D02C44491F006C34BB /* DeleteLocalUseCase.swift in Sources */,
 				08B183C52C4421D5006C34BB /* TextUnderBarButtonCPNT.swift in Sources */,

--- a/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk.git",
       "state" : {
-        "revision" : "08089eeffc9b442da1c7343a70bf66c6de1a72c9",
-        "version" : "2.22.4"
+        "revision" : "66b3bddc2657e8ccb7a16fa0264aac99c57be09b",
+        "version" : "2.22.5"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk-rx",
       "state" : {
-        "revision" : "bdcb118183ef59a75753a69ac5d3cc93def0baa3",
-        "version" : "2.22.4"
+        "revision" : "b5d6cd4bbf29e5e2a79b8a1d3c43e8df606dbb40",
+        "version" : "2.22.5"
       }
     },
     {

--- a/PopPool/PopPool/Presentation/Components/ListInfoButton.swift
+++ b/PopPool/PopPool/Presentation/Components/ListInfoButton.swift
@@ -1,0 +1,163 @@
+//
+//  ListInfoButton.swift
+//  PopPool
+//
+//  Created by Porori on 7/23/24.
+//
+
+import UIKit
+import SnapKit
+
+final class ListInfoButton: UIStackView {
+    
+    enum ButtonStyle {
+        case button(String)
+        case icon
+        case toggle
+    }
+    
+    // MARK: - Component
+    
+    private let topSpaceView = UIView()
+    private let bottomSpaceView = UIView()
+    
+    private let profileImageView: UIImageView = {
+        let imgView = UIImageView()
+        imgView.image = UIImage(systemName: "person.fill")
+        imgView.backgroundColor = .black
+        imgView.contentMode = .scaleAspectFit
+        imgView.clipsToBounds = true
+        return imgView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .bold, size: 14)
+        return label
+    }()
+    
+    private let subLabel: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .regular, size: 12)
+        return label
+    }()
+    
+    lazy var titleStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.addArrangedSubview(titleLabel)
+        stack.addArrangedSubview(subLabel)
+        return stack
+    }()
+    
+    lazy var profileStack: UIStackView = {
+        let stack = UIStackView()
+        stack.addArrangedSubview(profileImageView)
+        stack.addArrangedSubview(titleStack)
+        stack.spacing = 12
+        stack.layoutMargins = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 16)
+        stack.isLayoutMarginsRelativeArrangement = true
+        return stack
+    }()
+    
+    // MARK: - Initializer
+    
+    init(infoTitle: String, subTitle: String, style: ButtonStyle) {
+        super.init(frame: .zero)
+        setUp()
+        setUpConstraints()
+        setStyle(title: infoTitle, subTitle: subTitle, style: style)
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        profileImageView.layer.cornerRadius = profileImageView.frame.size.height/2
+    }
+    
+    // MARK: - Methods
+    
+    private func setUp() {
+        self.axis = .vertical
+    }
+    
+    private func setUpConstraints() {
+        self.addArrangedSubview(topSpaceView)
+        self.addArrangedSubview(profileStack)
+        self.addArrangedSubview(bottomSpaceView)
+        
+        topSpaceView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide.small100)
+        }
+        
+        bottomSpaceView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide.small100)
+        }
+        
+        profileImageView.snp.makeConstraints { make in
+            make.size.equalTo(Constants.spaceGuide.medium200)
+        }
+    }
+    
+    /// Date 타입으로 변환 가능 여부를 파악하여 날짜 혹은 String을 반환합니다
+    /// - Parameter input: userId 혹은 날짜를 받습니다
+    /// - Returns: String 타입을 반환합니다
+    private func checkIfDate(input: String) -> String {
+        
+        // 서버에서 받는 Date 형식에 따라 ISODateFormatter 활용 여부 변경 예정
+        let isoDateFomatter = ISO8601DateFormatter()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(identifier: "UTC")
+        
+        if let date = isoDateFomatter.date(from: input) {
+            let formattedDate = dateFormatter.string(from: date)
+            return formattedDate
+        } else {
+            return input
+        }
+    }
+    
+    private func setStyle(title: String, subTitle: String, style: ButtonStyle) {
+        let isDate = checkIfDate(input: subTitle)
+        titleLabel.text = title
+        subLabel.text = isDate
+        subLabel.textColor = .g400
+        
+        switch style {
+        case .button(let buttonName):            
+            let button = UIButton()
+            button.setTitle(buttonName, for: .normal)
+            button.setContentHuggingPriority(.required, for: .horizontal)
+            button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+            
+            button.titleLabel?.font = .EngFont(style: .regular, size: 13)
+            button.backgroundColor = .red
+            button.layer.cornerRadius = 4
+            button.clipsToBounds = true
+            
+            profileStack.setCustomSpacing(42, after: titleStack)
+            profileStack.addArrangedSubview(button)
+            
+        case .icon:
+            let button = UIButton()
+            button.setImage(UIImage(named: "line_signUp"), for: .normal)
+            button.contentMode = .scaleAspectFit
+            button.contentEdgeInsets = UIEdgeInsets(top: 9.5, left: 0, bottom: 9.5, right: 0)
+            
+            button.snp.makeConstraints { make in
+                make.width.equalTo(22)
+            }
+            
+            profileStack.setCustomSpacing(42, after: titleStack)
+            profileStack.addArrangedSubview(button)
+            
+        case .toggle:            
+            let toggle = UISwitch()
+            toggle.onTintColor = .blu400
+            profileStack.addArrangedSubview(toggle)
+        }
+    }
+}

--- a/PopPool/PopPool/Presentation/Components/ListMenuCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ListMenuCPNT.swift
@@ -9,64 +9,68 @@ import UIKit
 import RxSwift
 import SnapKit
 
-class ListMenuCPNT: UIStackView {
+final class ListMenuCPNT: UIStackView {
     
-    enum MenuOption {
+    //MARK: - Menu Button Options
+    
+    enum MenuStyle {
         case none
-        case menu
+        case menu(String)
         case filter(UIImage?)
     }
     
-    // 타이틀
-    let titleLabel: UILabel = {
+    //MARK: - Components
+    
+    private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .KorFont(style: .regular, size: 15)
         return label
     }()
     
-    // 서브 버튼 텍스트
-    let optionTitle: UILabel = {
+    private let subTitle: UILabel = {
         let label = UILabel()
         label.font = .KorFont(style: .regular, size: 13)
         return label
     }()
     
-    let icon: UIButton = {
+    private let iconButton: UIButton = {
         let button = UIButton()
         return button
     }()
     
-    let topSpaceView = UIView()
-    let bottomSpaceView = UIView()
-    
     lazy var titleStack: UIStackView = {
         let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.backgroundColor = .green
         stack.addArrangedSubview(titleLabel)
-        stack.addArrangedSubview(optionTitle)
-        stack.addArrangedSubview(icon)
+        stack.addArrangedSubview(subTitle)
+        stack.addArrangedSubview(iconButton)
+        stack.spacing = 6
         stack.layoutMargins = UIEdgeInsets(top: 0, left: 22, bottom: 0, right: 18)
         stack.isLayoutMarginsRelativeArrangement = true
         return stack
     }()
     
-    init(menuTitle: String, style: MenuOption) {
-        self.titleLabel.text = menuTitle
+    private let topSpaceView = UIView()
+    private let bottomSpaceView = UIView()
+    
+    //MARK: - Initializer
+    
+    init(titleText: String, style: MenuStyle) {
+        self.titleLabel.text = titleText
         super.init(frame: .zero)
         setUp()
         setUpConstraints()
-        setStyle(title: menuTitle, style: style)
+        setStyle(title: titleText, style: style)
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    //MARK: - Method
+    
     private func setUp() {
         self.axis = .vertical
-        topSpaceView.backgroundColor = .yellow
-        bottomSpaceView.backgroundColor = .yellow
+        self.titleLabel.textColor = .g1000
     }
     
     private func setUpConstraints() {
@@ -82,24 +86,33 @@ class ListMenuCPNT: UIStackView {
             make.height.equalTo(Constants.spaceGuide.small100)
         }
         
-        icon.snp.makeConstraints { make in
+        iconButton.snp.makeConstraints { make in
             make.size.equalTo(22)
         }
     }
     
-    private func setStyle(title: String, style: MenuOption) {
+    /// 버튼 스타일에 따라 다른 값을 제공하는 메서드입니다
+    /// - Parameters:
+    ///   - title: String 타입을 받습니다
+    ///   - style: MenuStyle을 받아 switch로 분기를 확인합니다
+    private func setStyle(title: String, style: MenuStyle) {
         titleLabel.text = title
-        icon.setImage(UIImage(named: "line_signUp"), for: .normal)
+        iconButton.setImage(UIImage(named: "line_signUp"), for: .normal)
+        titleStack.setCustomSpacing(42, after: titleLabel)
         
         switch style {
         case .filter(let image):
-            optionTitle.text = "필터옵션"
-            icon.setImage(image, for: .normal)
-        case .menu:
-            optionTitle.text = "메뉴정보"
-            optionTitle.textColor = .blu500
+            subTitle.text = "필터옵션"
+            subTitle.textColor = .g1000
+            titleLabel.textColor = .g400
+            iconButton.setImage(image, for: .normal)
+            
+        case .menu(let title):
+            subTitle.text = title
+            subTitle.textColor = .blu500
+            
         case .none:
-            optionTitle.text = ""
+            subTitle.text = ""
         }
     }
 }

--- a/PopPool/PopPool/Presentation/Components/ListMenuCPNT.swift
+++ b/PopPool/PopPool/Presentation/Components/ListMenuCPNT.swift
@@ -1,0 +1,105 @@
+//
+//  ListMenuCPNT.swift
+//  PopPool
+//
+//  Created by Porori on 7/22/24.
+//
+
+import UIKit
+import RxSwift
+import SnapKit
+
+class ListMenuCPNT: UIStackView {
+    
+    enum MenuOption {
+        case none
+        case menu
+        case filter(UIImage?)
+    }
+    
+    // 타이틀
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .regular, size: 15)
+        return label
+    }()
+    
+    // 서브 버튼 텍스트
+    let optionTitle: UILabel = {
+        let label = UILabel()
+        label.font = .KorFont(style: .regular, size: 13)
+        return label
+    }()
+    
+    let icon: UIButton = {
+        let button = UIButton()
+        return button
+    }()
+    
+    let topSpaceView = UIView()
+    let bottomSpaceView = UIView()
+    
+    lazy var titleStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.backgroundColor = .green
+        stack.addArrangedSubview(titleLabel)
+        stack.addArrangedSubview(optionTitle)
+        stack.addArrangedSubview(icon)
+        stack.layoutMargins = UIEdgeInsets(top: 0, left: 22, bottom: 0, right: 18)
+        stack.isLayoutMarginsRelativeArrangement = true
+        return stack
+    }()
+    
+    init(menuTitle: String, style: MenuOption) {
+        self.titleLabel.text = menuTitle
+        super.init(frame: .zero)
+        setUp()
+        setUpConstraints()
+        setStyle(title: menuTitle, style: style)
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUp() {
+        self.axis = .vertical
+        topSpaceView.backgroundColor = .yellow
+        bottomSpaceView.backgroundColor = .yellow
+    }
+    
+    private func setUpConstraints() {
+        self.addArrangedSubview(topSpaceView)
+        self.addArrangedSubview(titleStack)
+        self.addArrangedSubview(bottomSpaceView)
+        
+        topSpaceView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide.small100)
+        }
+        
+        bottomSpaceView.snp.makeConstraints { make in
+            make.height.equalTo(Constants.spaceGuide.small100)
+        }
+        
+        icon.snp.makeConstraints { make in
+            make.size.equalTo(22)
+        }
+    }
+    
+    private func setStyle(title: String, style: MenuOption) {
+        titleLabel.text = title
+        icon.setImage(UIImage(named: "line_signUp"), for: .normal)
+        
+        switch style {
+        case .filter(let image):
+            optionTitle.text = "필터옵션"
+            icon.setImage(image, for: .normal)
+        case .menu:
+            optionTitle.text = "메뉴정보"
+            optionTitle.textColor = .blu500
+        case .none:
+            optionTitle.text = ""
+        }
+    }
+}


### PR DESCRIPTION
## Description
- 차단 프로필 페이지에서 활용되는 컴포넌트를 생성하였습니다.
- 필요에 따라 버튼명 등은 변경할 수 있습니다.

## Example

### ListInfoButton

<img width="750" alt="Screenshot 2024-07-23 at 19 32 34" src="https://github.com/user-attachments/assets/4553d718-48e3-4e7a-ab44-e033569918e3">

```
let test = ListInfoButton(infoTitle: "분노하는 너구리", subTitle: "", style: .icon)
```

### ListMenuCPNT

<img width="808" alt="Screenshot 2024-07-23 at 16 12 01" src="https://github.com/user-attachments/assets/eb6f2b3e-ef9c-410e-a589-42a618af33b2">

```
let test = ListMenuCPNT(titleText: "메뉴명", style: .menu("메뉴정보"))
```
