### PR TITLE
[HOTFIX]: 💥🚚 병합 후 프로젝트 파일 충돌 이슈 해결

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -1590,6 +1590,7 @@
 			);
 			path = HomeRepository;
 			sourceTree = "<group>";
+        };
 		BD8DE8212C68653300C5DE8B /* Home */ = {
 			isa = PBXGroup;
 			children = (


### PR DESCRIPTION
## Description
- HomeDTO 병합 이후 project 파일에서 누락된  '};'로 빌드가 되지 않던 이슈 해결