### PR TITLE
MERGE: ✅ 탭바 적용 이후 섹션별 헤더 탭 안되는 이슈 해결

### DIFF
--- a/PopPool/PopPool/Presentation/Scene/MyPage/Home/HomeVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/MyPage/Home/HomeVC.swift
@@ -309,7 +309,6 @@ final class HomeVC: BaseViewController, UICollectionViewDelegate {
                 header.actionTapped
                     .withUnretained(self)
                     .subscribe(onNext: { (owner, _) in
-                        guard self.navigationController?.topViewController == self else { return }
                         let response = self.viewModel.myHomeAPIResponse.value
                         print("응답데이터: \(response)") // 로그 추가
 
@@ -317,13 +316,11 @@ final class HomeVC: BaseViewController, UICollectionViewDelegate {
                         case .topBanner: return
                         case .custom:
 
-                                   guard let customPopUpStoreList = response.customPopUpStoreList, !customPopUpStoreList.isEmpty else {
-                                       print("맞춤 팝업 데이터가 없습니다.")
-                                       print(" 헤더 탭")
-                                       return
-
-                                   }
-                            print("헤더탭탭")
+                            guard let customPopUpStoreList = response.customPopUpStoreList, !customPopUpStoreList.isEmpty else {
+                                print("맞춤 팝업 데이터가 없습니다.")
+                                return
+                            }
+                            
                             let data: GetHomeInfoResponse = .init(
                                 customPopUpStoreList: response.customPopUpStoreList,
                                 customPopUpStoreTotalPages: response.customPopUpStoreTotalPages,
@@ -362,7 +359,7 @@ final class HomeVC: BaseViewController, UICollectionViewDelegate {
                             owner.navigationController?.pushViewController(vc, animated: true)
                         }
                     })
-                    .disposed(by: self.disposeBag)
+                    .disposed(by: header.disposeBag)
 
                 return header
             }

--- a/PopPool/PopPool/Presentation/Scene/MyPage/Home/SectionHeaderCell.swift
+++ b/PopPool/PopPool/Presentation/Scene/MyPage/Home/SectionHeaderCell.swift
@@ -50,7 +50,9 @@ final class SectionHeaderCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    let actionTapped = PublishSubject<Void>()
+    var actionTapped: Observable<Void> {
+        return actionButton.rx.tap.asObservable()
+    }
     var disposeBag = DisposeBag()
     
     // MARK: - Initializer
@@ -59,7 +61,6 @@ final class SectionHeaderCell: UICollectionViewCell {
         super.init(frame: frame)
         setUp()
         setUpConstraint()
-        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -69,7 +70,6 @@ final class SectionHeaderCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         disposeBag = DisposeBag()
-        bind()
     }
     
     // MARK: - Methods
@@ -86,12 +86,6 @@ final class SectionHeaderCell: UICollectionViewCell {
     public func configureWhite(title: String) {
         titleLabel.text = title
         titleLabel.textColor = .w100
-    }
-    
-    private func bind() {
-        actionButton.rx.tap
-            .bind(to: actionTapped)
-            .disposed(by: disposeBag)
     }
     
     private func setUp() {

--- a/PopPool/PopPool/Presentation/Scene/MyPage/Home/SectionHeaderCell.swift
+++ b/PopPool/PopPool/Presentation/Scene/MyPage/Home/SectionHeaderCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 import SnapKit
 import RxSwift
+import RxCocoa
 
 final class SectionHeaderCell: UICollectionViewCell {
     
@@ -49,11 +50,8 @@ final class SectionHeaderCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    var actionTapped: Observable<Void> {
-        return actionButton.rx.tap.asObservable()
-    }
-    
-    let disposeBag = DisposeBag()
+    let actionTapped = PublishSubject<Void>()
+    var disposeBag = DisposeBag()
     
     // MARK: - Initializer
     
@@ -61,10 +59,17 @@ final class SectionHeaderCell: UICollectionViewCell {
         super.init(frame: frame)
         setUp()
         setUpConstraint()
+        bind()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+        bind()
     }
     
     // MARK: - Methods
@@ -81,6 +86,12 @@ final class SectionHeaderCell: UICollectionViewCell {
     public func configureWhite(title: String) {
         titleLabel.text = title
         titleLabel.textColor = .w100
+    }
+    
+    private func bind() {
+        actionButton.rx.tap
+            .bind(to: actionTapped)
+            .disposed(by: disposeBag)
     }
     
     private func setUp() {


### PR DESCRIPTION
## Description
- 섹션별 헤더 탭 시 알맞는 페이지로 이동이 가능합니다.

## Changes
- 탭바 적용 이후 섹션별 헤더 탭이 안되는 이슈를 해결했습니다.
- 섹션별 switch문의 분기를 제대로 타고 있지 않아 dataSource 내부에서 활용하던 self = navigationController.topViewController를 제거하였습니다
- 셀이 재사용되면서 데이터를 반복적으로 호출하는 이슈 발견, reuseCell 메서드를 추가 적용
- dispose가 제대로 되지 않고 있던 이슈 발견, 셀의 disposebag로 이벤트 처리 권한을 넘김
