### PR TITLE
[MERGE]: ✅ loadingIndicator 적용

### DIFF
--- a/PopPool/PopPool.xcodeproj/project.pbxproj
+++ b/PopPool/PopPool.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		BD6368082C0CBEFE00891A1B /* PopPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6368072C0CBEFE00891A1B /* PopPoolTests.swift */; };
 		BD67FA402C9202EF00E89E7D /* SocialCommentVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD67FA3F2C9202EF00E89E7D /* SocialCommentVC.swift */; };
 		BD67FA422C9221BB00E89E7D /* SocialNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD67FA412C9221BB00E89E7D /* SocialNoticeView.swift */; };
+		BD68E7C02CABC2F900F25D5B /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD68E7BF2CABC2F900F25D5B /* UIImageView+.swift */; };
 		BD702D592C8793AA00142AE0 /* SignOutTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD702D582C8793AA00142AE0 /* SignOutTableViewCell.swift */; };
 		BD702D5F2C883FCA00142AE0 /* SignOutCompleteVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD702D5E2C883FCA00142AE0 /* SignOutCompleteVM.swift */; };
 		BD702D632C88511E00142AE0 /* PP_splash.json in Resources */ = {isa = PBXBuildFile; fileRef = BD702D622C88511E00142AE0 /* PP_splash.json */; };
@@ -667,6 +668,7 @@
 		BD6368072C0CBEFE00891A1B /* PopPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopPoolTests.swift; sourceTree = "<group>"; };
 		BD67FA3F2C9202EF00E89E7D /* SocialCommentVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialCommentVC.swift; sourceTree = "<group>"; };
 		BD67FA412C9221BB00E89E7D /* SocialNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialNoticeView.swift; sourceTree = "<group>"; };
+		BD68E7BF2CABC2F900F25D5B /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		BD702D582C8793AA00142AE0 /* SignOutTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutTableViewCell.swift; sourceTree = "<group>"; };
 		BD702D5E2C883FCA00142AE0 /* SignOutCompleteVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignOutCompleteVM.swift; sourceTree = "<group>"; };
 		BD702D622C88511E00142AE0 /* PP_splash.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PP_splash.json; sourceTree = "<group>"; };
@@ -2076,6 +2078,7 @@
 				0896A05B2C79F9300062CC49 /* String+.swift */,
 				0896A05D2C79F9380062CC49 /* Date+.swift */,
 				BD2684952C8C901F000F623F /* UICollectionReusableView.swift */,
+				BD68E7BF2CABC2F900F25D5B /* UIImageView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2354,6 +2357,7 @@
 				4E4DC0162C6201B8007CE63A /* PopUpStoreDTO.swift in Sources */,
 				BD3C4C6F2C313D6C0087917B /* LoginBottomSheetVM.swift in Sources */,
 				08E23AC52C4F9298004B77B6 /* UserRepository.swift in Sources */,
+				BD68E7C02CABC2F900F25D5B /* UIImageView+.swift in Sources */,
 				BDF3B2AA2C0BE23D00B079C5 /* Requestable.swift in Sources */,
 				089D19272C3AEB53000435D9 /* MyPageMainProfileView.swift in Sources */,
 				4E67A14D2C92FB02003BDAFA /* PopPoolAPIEndPoint.swift in Sources */,

--- a/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PopPool/PopPool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,12 +20,39 @@
       }
     },
     {
+      "identity" : "iqkeyboardcore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hackiftekhar/IQKeyboardCore.git",
+      "state" : {
+        "revision" : "3959266e4b064259d798df942e61037d12415a33",
+        "version" : "1.0.6"
+      }
+    },
+    {
       "identity" : "iqkeyboardmanager",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hackiftekhar/IQKeyboardManager.git",
       "state" : {
-        "revision" : "fa9b2bac94b3fabe2d6ca7c74b269d4e8c355111",
-        "version" : "7.1.1"
+        "revision" : "0d9b0277275b8c5f5cd13daf52e988ff44c8f066",
+        "version" : "7.2.0"
+      }
+    },
+    {
+      "identity" : "iqkeyboardnotification",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hackiftekhar/IQKeyboardNotification.git",
+      "state" : {
+        "revision" : "7d225c8e93f6072ae6ae0dbe774fe8d2f4a21255",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "iqtextinputviewnotification",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hackiftekhar/IQTextInputViewNotification.git",
+      "state" : {
+        "revision" : "0d274f3900c2257e39b37561a0486120813fd43b",
+        "version" : "1.0.6"
       }
     },
     {
@@ -96,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift",
       "state" : {
-        "revision" : "b06a8c8596e4c3e8e7788e08e720e3248563ce6a",
-        "version" : "6.7.1"
+        "revision" : "c7c7d2cf50a3211fe2843f76869c698e4e417930",
+        "version" : "6.8.0"
       }
     },
     {

--- a/PopPool/PopPool/Data/Network/PopPoolNetwork/AdminDTO/AdminPopUpStoreDTO.swift
+++ b/PopPool/PopPool/Data/Network/PopPoolNetwork/AdminDTO/AdminPopUpStoreDTO.swift
@@ -15,7 +15,6 @@ struct AdminPopUpStoreDTO: Codable {
     let address: String?
     let startDate: String?
     let endDate: String?
-    let bannerYn: Bool
     let mainImageUrl: String?
     let imageUrl: [String]?
 }

--- a/PopPool/PopPool/Presentation/Common/Extension/UIImageView+.swift
+++ b/PopPool/PopPool/Presentation/Common/Extension/UIImageView+.swift
@@ -1,0 +1,29 @@
+//
+//  UIImageView+.swift
+//  PopPool
+//
+//  Created by Porori on 10/1/24.
+//
+
+import UIKit
+import SnapKit
+
+extension UIImageView {
+    func stopLoadingIndicator() {
+        self.subviews.forEach { subview in
+            if let loadingIndicator = subview as? LoadingIndicator {
+                loadingIndicator.stopIndicator()
+            }
+        }
+    }
+    
+    func showLoadingIndicator() {
+        if self.image == nil {
+            stopLoadingIndicator()
+            let loadingIndicator = LoadingIndicator(frame: self.bounds)
+            self.addSubview(loadingIndicator)
+            
+            loadingIndicator.startIndicator()
+        }
+    }
+}

--- a/PopPool/PopPool/Presentation/Common/Extension/UIImageView+.swift
+++ b/PopPool/PopPool/Presentation/Common/Extension/UIImageView+.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import RxSwift
 
 extension UIImageView {
     func stopLoadingIndicator() {
@@ -18,12 +19,35 @@ extension UIImageView {
     }
     
     func showLoadingIndicator() {
-        if self.image == nil {
-            stopLoadingIndicator()
-            let loadingIndicator = LoadingIndicator(frame: self.bounds)
-            self.addSubview(loadingIndicator)
-            
-            loadingIndicator.startIndicator()
-        }
+        stopLoadingIndicator()
+        
+        let loadingIndicator = LoadingIndicator(frame: self.bounds)
+        loadingIndicator.startIndicator()
+        
+        self.addSubview(loadingIndicator)
+    }
+    
+    func setPresignedImage(from string: [String], service: PreSignedService, bag: DisposeBag) {
+        self.image = UIImage(systemName: "lasso")
+        self.showLoadingIndicator()
+        print("이미지 처리 준비!!")
+        
+        service.tryDownload(filePaths: string)
+            .subscribe(onSuccess: { [weak self] images in
+                print("이미지 처리 중!!")
+                guard let self = self else { return }
+                guard let image = images.first else { return }
+                DispatchQueue.main.async {
+                    self.image = image
+                    self.stopLoadingIndicator()
+                }
+            }, onFailure: { [weak self] error in
+                guard let self = self else { return }
+                print("이미지 처리가 안됐다!!!")
+                DispatchQueue.main.async {
+                    self.stopLoadingIndicator() // 이미지는 최초에 걸어둔 친구가 있기 때문에 따로 처리하지 않아도 된다.
+                }
+            })
+            .disposed(by: bag)
     }
 }

--- a/PopPool/PopPool/Presentation/Common/Extension/UIImageView+.swift
+++ b/PopPool/PopPool/Presentation/Common/Extension/UIImageView+.swift
@@ -27,14 +27,13 @@ extension UIImageView {
         self.addSubview(loadingIndicator)
     }
     
+    /// 적용하여 loadingIndicator를 호출할 수 있습니다.
     func setPresignedImage(from string: [String], service: PreSignedService, bag: DisposeBag) {
-        self.image = UIImage(systemName: "lasso")
+        self.image = nil
         self.showLoadingIndicator()
-        print("이미지 처리 준비!!")
         
         service.tryDownload(filePaths: string)
             .subscribe(onSuccess: { [weak self] images in
-                print("이미지 처리 중!!")
                 guard let self = self else { return }
                 guard let image = images.first else { return }
                 DispatchQueue.main.async {
@@ -43,7 +42,6 @@ extension UIImageView {
                 }
             }, onFailure: { [weak self] error in
                 guard let self = self else { return }
-                print("이미지 처리가 안됐다!!!")
                 DispatchQueue.main.async {
                     self.stopLoadingIndicator() // 이미지는 최초에 걸어둔 친구가 있기 때문에 따로 처리하지 않아도 된다.
                 }

--- a/PopPool/PopPool/Presentation/Components/LoadingIndicator.swift
+++ b/PopPool/PopPool/Presentation/Components/LoadingIndicator.swift
@@ -17,12 +17,12 @@ final class LoadingIndicator: UIView {
         return view
     }()
     
-    init() {
-        super.init(frame: .zero)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
         setUp()
         setUpConstraint()
     }
-    
+        
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -39,12 +39,12 @@ final class LoadingIndicator: UIView {
         }
     }
     
-    public func start() {
+    public func startIndicator() {
         animationView.play()
         animationView.loopMode = .loop
     }
     
-    public func stop() {
+    public func stopIndicator() {
         self.removeFromSuperview()
         animationView.stop()
         animationView.removeFromSuperview()

--- a/PopPool/PopPool/Presentation/Scene/Admin/Edit/AdminEditVC.swift
+++ b/PopPool/PopPool/Presentation/Scene/Admin/Edit/AdminEditVC.swift
@@ -23,7 +23,6 @@ final class AdminEditVC: BaseViewController {
     private let mainImageIndex: BehaviorRelay<Int> = .init(value: -1)
     private let selectCategory: BehaviorRelay<String> = .init(value: "카테고리")
     private let address: BehaviorRelay<String?> = .init(value: nil)
-    private let bannerYn: BehaviorRelay<Bool> = .init(value: false)
     private let latitude: BehaviorRelay<Double?> = .init(value: nil)
     private let longitude: BehaviorRelay<Double?> = .init(value: nil)
     private let startDate: BehaviorRelay<String?> = .init(value: nil)
@@ -519,7 +518,6 @@ private extension AdminEditVC {
                                 address: adress,
                                 startDate: startDate,
                                 endDate: endDate,
-                                bannerYn: owner.bannerYn.value,
                                 mainImageUrl: pathList[owner.mainImageIndex.value],
                                 imageUrl: pathList
                             )
@@ -653,14 +651,11 @@ private extension AdminEditVC {
            let longitude = longitude.value,
            let startDate = startDate.value,
            let endDate = endDate.value,
-//           let bannerYn = bannerYn.value,
            let description = descriptionText.value,
            let adress = address.value,
            let marker = markerName.value,
            let snippet = snippet.value
         {
-            let bannerYn = bannerYn.value
-
 
             if images.value.count != 0 &&
                 mainImageIndex.value != -1 &&

--- a/PopPool/PopPool/Presentation/Scene/Admin/Management/AdminManagementListTableViewCell.swift
+++ b/PopPool/PopPool/Presentation/Scene/Admin/Management/AdminManagementListTableViewCell.swift
@@ -69,8 +69,14 @@ extension AdminManagementListTableViewCell: CellInputable {
     }
     
     func injectionWith(input: Input) {
-        popUpImageView.image = input.image
         titleLabel.text = input.title
         subTitleLabel.text = input.category
+        
+        if let image = input.image {
+            popUpImageView.image = image
+            popUpImageView.stopLoadingIndicator()
+        } else {
+            popUpImageView.showLoadingIndicator()
+        }
     }
 }

--- a/PopPool/PopPool/Presentation/Scene/MyPage/Home/HomeDetailPopUpCell.swift
+++ b/PopPool/PopPool/Presentation/Scene/MyPage/Home/HomeDetailPopUpCell.swift
@@ -205,13 +205,10 @@ extension HomeDetailPopUpCell: Cellable {
     
     func injectionWith(input: Input) {
         if let path = input.image {
-            print("테스트 시작")
             let service = PreSignedService()
             popUpImageView.setPresignedImage(from: [path], service: service, bag: disposeBag)
         } else {
-            print("이미지가 nil임")
-            let path = input.image
-            popUpImageView.image = UIImage(systemName: "lasso")
+            popUpImageView.image = UIImage(systemName: "defaultLogo")
         }
         
         titleLabel.text = input.title

--- a/PopPool/PopPool/Presentation/Scene/MyPage/Home/HomeDetailPopUpCell.swift
+++ b/PopPool/PopPool/Presentation/Scene/MyPage/Home/HomeDetailPopUpCell.swift
@@ -204,19 +204,14 @@ extension HomeDetailPopUpCell: Cellable {
     }
     
     func injectionWith(input: Input) {
-        popUpImageView.kf.indicatorType = .activity
-        popUpImageView.image = UIImage(named: "defaultLogo")
-        
         if let path = input.image {
-            service.tryDownload(filePaths: [path])
-                .subscribe { [weak self] images in
-                    guard let image = images.first else { return }
-                    self?.popUpImageView.image = image
-                } onFailure: { [weak self] error in
-                    self?.popUpImageView.image = UIImage(named: "defaultLogo")
-                    print("ImageDownLoad Fail")
-                }
-                .disposed(by: disposeBag)
+            print("테스트 시작")
+            let service = PreSignedService()
+            popUpImageView.setPresignedImage(from: [path], service: service, bag: disposeBag)
+        } else {
+            print("이미지가 nil임")
+            let path = input.image
+            popUpImageView.image = UIImage(systemName: "lasso")
         }
         
         titleLabel.text = input.title


### PR DESCRIPTION
## Description
- presignedUrl로 이미지 다운로드 시, indicator를 적요할 수 있는 UIImageView extension을 생성했습니다.
- setPresignedImage(from string: [String], service: PreSignedService, bag: DisposeBag)를 호출하여 적용해주세요.
*UIImageView를 확장하였기에 disposeBag를 넘겨주는 형태로 구성해보았습니다.

```swift
e.g)
func injectionWith(input: Input) {
        if let path = input.image {
        let service = PresignedService()
        let disposeBag = DisposeBag()

        testImageView.setPresignedImage(from: path, service: service, bag: disposeBag)
}
```

## Change
- 데이터 호출이 올바르게 되지 않아 bannerYn을 임시로 제거하였습니다.


https://github.com/user-attachments/assets/f12b9e6e-c68e-48b9-aea0-b20492328db3

