### PR TITLE
[fix] 지도 탭에서 카테고리태그가 합쳐치고 ... 축약되는 이슈 수정 

### DIFF
--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/FilterBottomSheetView.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/FilterBottomSheetView.swift
@@ -42,13 +42,13 @@ final class FilterBottomSheetView: UIView {
         let layout = UICollectionViewCompositionalLayout { section, _ in
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .estimated(26),
-                heightDimension: .absolute(36)
+                heightDimension: .estimated(36)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(36)
+                heightDimension: .estimated(36)
             )
             let group = NSCollectionLayoutGroup.horizontal(
                 layoutSize: groupSize,
@@ -391,16 +391,22 @@ extension FilterBottomSheetView {
         var filters: [String] = []
 
         if let locationText = locationText, !locationText.isEmpty {
-            filters.append(locationText)
+            let locations = locationText
+                              .split(separator: ",")
+                              .map { $0.trimmingCharacters(in: .whitespaces) }
+            filters += locations
         }
+
         if let categoryText = categoryText, !categoryText.isEmpty {
-            filters.append(categoryText)
+            let categories = categoryText
+                                .split(separator: ",")
+                                .map { $0.trimmingCharacters(in: .whitespaces) }
+            filters += categories
         }
 
         filterChipsView.updateChips(with: filters)
     }
 }
-
 extension FilterBottomSheetView: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateSelectedButtonPosition()


### PR DESCRIPTION
## 📌 이슈

- #129 

## ✅ 작업 사항
  `locationText`/`categoryText` 전체 문자열을 단일 필터로 append 하던 부분(`filters.append(...)`)을 제거  
  문자열을 `,` 로 split 하고, trim 후 각 요소를 개별 필터로 추가하도록 수정  

## 🚀 테스트 방식

https://github.com/user-attachments/assets/530f847c-8d4a-44bb-b818-98d38163cb23




