### PR TITLE
[FIX] 서브지역 카테고리 라벨 상단이 짤리던 이슈 수정 

### DIFF
--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonBackgroundView.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonBackgroundView.swift
@@ -34,7 +34,7 @@ final class BalloonBackgroundView: UIView {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .clear
         collectionView.isScrollEnabled = false
-        collectionView.register(BalloonChipCell.self, forCellWithReuseIdentifier: BalloonChipCell.identifier)
+        collectionView.register(BalloonChipCell.self, forCellWithReuseIdentifier: BalloonChipCell.identifiers)
         return collectionView
     }()
 
@@ -289,7 +289,7 @@ extension BalloonBackgroundView: UICollectionViewDataSource {
                         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard
             let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: BalloonChipCell.identifier,
+                withReuseIdentifier: BalloonChipCell.identifiers,
                 for: indexPath
             ) as? BalloonChipCell,
             let input = tagSection?.inputDataList[indexPath.item]

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
@@ -1,6 +1,7 @@
 import Infrastructure
 import SnapKit
 import UIKit
+import Then
 
 final class BalloonChipCell: UICollectionViewCell {
     static let identifier = "BalloonChipCell"
@@ -15,17 +16,15 @@ final class BalloonChipCell: UICollectionViewCell {
         static let fontSize: CGFloat = 11
     }
 
-    private let button: PPButton = {
-        let button = PPButton(
-            style: .secondary,
-            text: "",
-            font: .korFont(style: .medium, size: Constant.fontSize),
-            cornerRadius: 15
-        )
-        button.titleLabel?.lineBreakMode = .byTruncatingTail
-        button.titleLabel?.adjustsFontSizeToFitWidth = false
-        return button
-    }()
+    private let button = PPButton(
+        style: .secondary,
+        text: "",
+        font: .korFont(style: .medium, size: Constant.fontSize),
+        cornerRadius: 15
+    ).then {
+        $0.titleLabel?.lineBreakMode = .byTruncatingTail
+        $0.titleLabel?.adjustsFontSizeToFitWidth = false
+    }
 
     private var currentAction: UIAction?
 
@@ -46,34 +45,31 @@ final class BalloonChipCell: UICollectionViewCell {
     }
 
     func configure(with title: String, isSelected: Bool) {
-        let attributedTitle = NSMutableAttributedString(string: title)
-        attributedTitle.addAttribute(
-            .baselineOffset,
-            value: Constant.baselineOffset,
-            range: NSRange(location: .zero, length: attributedTitle.length)
-        )
+        let attributedTitle = NSMutableAttributedString(string: title).then {
+            $0.addAttribute(
+                .baselineOffset,
+                value: Constant.baselineOffset,
+                range: NSRange(location: .zero, length: $0.length)
+            )
+        }
 
         if isSelected {
-            let checkImage = UIImage(named: "icon_check_white")?
-                .withRenderingMode(.alwaysOriginal)
-                .resize(to: Constant.checkIconSize)
-            self.button.setImage(checkImage, for: .normal)
-            self.button.semanticContentAttribute = .forceRightToLeft
-            self.button.imageEdgeInsets = .init(
-                top: .zero,
-                left: 1,
-                bottom: .zero,
-                right: .zero
-            )
-            self.button.contentEdgeInsets = .init(
-                top: Constant.verticalInset,
-                left: Constant.selectedLeftInset,
-                bottom: Constant.verticalInset,
-                right: Constant.rightInset
-            )
-            self.button.setBackgroundColor(.blu500, for: .normal)
-            self.button.setTitleColor(.white, for: .normal)
-            self.button.layer.borderWidth = .zero
+            let checkImage = UIImage(named: "icon_check_white")?.withRenderingMode(.alwaysOriginal).resize(to: Constant.checkIconSize)
+
+            button.then {
+                $0.setImage(checkImage, for: .normal)
+                $0.semanticContentAttribute = .forceRightToLeft
+                $0.imageEdgeInsets = .init(top: .zero, left: 1, bottom: .zero, right: .zero)
+                $0.contentEdgeInsets = .init(
+                    top: Constant.verticalInset,
+                    left: Constant.selectedLeftInset,
+                    bottom: Constant.verticalInset,
+                    right: Constant.rightInset
+                )
+                $0.setBackgroundColor(.blu500, for: .normal)
+                $0.setTitleColor(.white, for: .normal)
+                $0.layer.borderWidth = .zero
+            }
 
             attributedTitle.addAttribute(
                 .font,
@@ -81,19 +77,21 @@ final class BalloonChipCell: UICollectionViewCell {
                 range: NSRange(location: .zero, length: attributedTitle.length)
             )
         } else {
-            self.button.setImage(nil, for: .normal)
-            self.button.semanticContentAttribute = .unspecified
-            self.button.imageEdgeInsets = .zero
-            self.button.contentEdgeInsets = .init(
-                top: Constant.verticalInset,
-                left: Constant.normalLeftInset,
-                bottom: Constant.verticalInset,
-                right: Constant.rightInset
-            )
-            self.button.setBackgroundColor(.white, for: .normal)
-            self.button.setTitleColor(.g400, for: .normal)
-            self.button.layer.borderWidth = 1
-            self.button.layer.borderColor = UIColor.g200.cgColor
+            button.then {
+                $0.setImage(nil, for: .normal)
+                $0.semanticContentAttribute = .unspecified
+                $0.imageEdgeInsets = .zero
+                $0.contentEdgeInsets = .init(
+                    top: Constant.verticalInset,
+                    left: Constant.normalLeftInset,
+                    bottom: Constant.verticalInset,
+                    right: Constant.rightInset
+                )
+                $0.setBackgroundColor(.white, for: .normal)
+                $0.setTitleColor(.g400, for: .normal)
+                $0.layer.borderWidth = 1
+                $0.layer.borderColor = UIColor.g200.cgColor
+            }
 
             attributedTitle.addAttribute(
                 .font,
@@ -110,15 +108,18 @@ final class BalloonChipCell: UICollectionViewCell {
             if let oldAction = currentAction {
                 self.button.removeAction(oldAction, for: .touchUpInside)
             }
+
             let action = UIAction { [weak self] _ in
                 guard let self = self else { return }
                 self.buttonAction?()
             }
+
             self.button.addAction(action, for: .touchUpInside)
             self.currentAction = action
         }
     }
 }
+
 extension UIImage {
     func resize(to size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0.0)

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
@@ -4,8 +4,6 @@ import Infrastructure
 
 import SnapKit
 import Then
-import UIKit
-
 final class BalloonChipCell: UICollectionViewCell {
 
     private enum Constant {

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
@@ -1,10 +1,11 @@
-import Infrastructure
-import SnapKit
 import UIKit
+
+import Infrastructure
+
+import SnapKit
 import Then
 
 final class BalloonChipCell: UICollectionViewCell {
-    static let identifier = "BalloonChipCell"
 
     private enum Constant {
         static let verticalInset: CGFloat = 6

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
@@ -4,7 +4,6 @@ import Infrastructure
 
 import SnapKit
 import Then
-import UIKit
 
 final class BalloonChipCell: UICollectionViewCell {
 

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
@@ -1,7 +1,7 @@
 import Infrastructure
 import SnapKit
-import UIKit
 import Then
+import UIKit
 
 final class BalloonChipCell: UICollectionViewCell {
     static let identifier = "BalloonChipCell"

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/BalloonChipCell.swift
@@ -1,88 +1,129 @@
+import Infrastructure
 import SnapKit
 import UIKit
 
 final class BalloonChipCell: UICollectionViewCell {
-   static let identifier = "BalloonChipCell"
+    static let identifier = "BalloonChipCell"
 
-   private let button: PPButton = {
-       let button = PPButton(
-           style: .secondary,
-           text: "",
-           font: .korFont(style: .medium, size: 11),
-           cornerRadius: 15
-       )
+    private enum Constant {
+        static let verticalInset: CGFloat = 6
+        static let selectedLeftInset: CGFloat = 10
+        static let normalLeftInset: CGFloat = 12
+        static let rightInset: CGFloat = 12
+        static let checkIconSize: CGSize = .init(width: 16, height: 16)
+        static let baselineOffset: CGFloat = -1
+        static let fontSize: CGFloat = 11
+    }
 
-       button.titleLabel?.lineBreakMode = .byTruncatingTail
-       button.titleLabel?.adjustsFontSizeToFitWidth = false
-       return button
-   }()
+    private let button: PPButton = {
+        let button = PPButton(
+            style: .secondary,
+            text: "",
+            font: .korFont(style: .medium, size: Constant.fontSize),
+            cornerRadius: 15
+        )
+        button.titleLabel?.lineBreakMode = .byTruncatingTail
+        button.titleLabel?.adjustsFontSizeToFitWidth = false
+        return button
+    }()
 
-   override init(frame: CGRect) {
-       super.init(frame: frame)
-       contentView.addSubview(button)
-       setupLayout()
-   }
+    private var currentAction: UIAction?
 
-   required init?(coder: NSCoder) {
-       fatalError("init(coder:) has not been implemented")
-   }
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(button)
+        setupLayout()
+    }
 
-   private func setupLayout() {
-       button.snp.makeConstraints { make in
-           make.edges.equalToSuperview()
-       }
-   }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
-   func configure(with title: String, isSelected: Bool) {
-       button.setTitle(title, for: .normal)
-       if isSelected {
-           let checkImage = UIImage(named: "icon_check_white")?.withRenderingMode(.alwaysOriginal)
-           let resizedImage = checkImage?.resize(to: CGSize(width: 16, height: 16))
-           button.setImage(resizedImage, for: .normal)
-           button.semanticContentAttribute = .forceRightToLeft
-           button.imageEdgeInsets = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: 0)
-           button.contentEdgeInsets = UIEdgeInsets(top: 4, left: 10, bottom: 6, right: 12)
-           button.setBackgroundColor(.blu500, for: .normal)
-           button.setTitleColor(.white, for: .normal)
-           button.layer.borderWidth = 0
-           button.titleLabel?.font = .korFont(style: .bold, size: 11)
+    private func setupLayout() {
+        button.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
 
-       } else {
-           button.setImage(nil, for: .normal)
-           button.semanticContentAttribute = .unspecified
-           button.imageEdgeInsets = .zero
-           button.contentEdgeInsets = UIEdgeInsets(top: 4, left: 12, bottom: 6, right: 12)
-           button.setBackgroundColor(.white, for: .normal)
-           button.setTitleColor(.g400, for: .normal)
-           button.layer.borderWidth = 1
-           button.layer.borderColor = UIColor.g200.cgColor
-           button.titleLabel?.font = .korFont(style: .medium, size: 11)
+    func configure(with title: String, isSelected: Bool) {
+        let attributedTitle = NSMutableAttributedString(string: title)
+        attributedTitle.addAttribute(
+            .baselineOffset,
+            value: Constant.baselineOffset,
+            range: NSRange(location: .zero, length: attributedTitle.length)
+        )
 
-       }
-   }
+        if isSelected {
+            let checkImage = UIImage(named: "icon_check_white")?
+                .withRenderingMode(.alwaysOriginal)
+                .resize(to: Constant.checkIconSize)
+            self.button.setImage(checkImage, for: .normal)
+            self.button.semanticContentAttribute = .forceRightToLeft
+            self.button.imageEdgeInsets = .init(
+                top: .zero,
+                left: 1,
+                bottom: .zero,
+                right: .zero
+            )
+            self.button.contentEdgeInsets = .init(
+                top: Constant.verticalInset,
+                left: Constant.selectedLeftInset,
+                bottom: Constant.verticalInset,
+                right: Constant.rightInset
+            )
+            self.button.setBackgroundColor(.blu500, for: .normal)
+            self.button.setTitleColor(.white, for: .normal)
+            self.button.layer.borderWidth = .zero
 
-   private var currentAction: UIAction?
+            attributedTitle.addAttribute(
+                .font,
+                value: UIFont.korFont(style: .bold, size: Constant.fontSize)!,
+                range: NSRange(location: .zero, length: attributedTitle.length)
+            )
+        } else {
+            self.button.setImage(nil, for: .normal)
+            self.button.semanticContentAttribute = .unspecified
+            self.button.imageEdgeInsets = .zero
+            self.button.contentEdgeInsets = .init(
+                top: Constant.verticalInset,
+                left: Constant.normalLeftInset,
+                bottom: Constant.verticalInset,
+                right: Constant.rightInset
+            )
+            self.button.setBackgroundColor(.white, for: .normal)
+            self.button.setTitleColor(.g400, for: .normal)
+            self.button.layer.borderWidth = 1
+            self.button.layer.borderColor = UIColor.g200.cgColor
 
-   var buttonAction: (() -> Void)? {
-       didSet {
-           if let oldAction = currentAction {
-               button.removeAction(oldAction, for: .touchUpInside)
-           }
+            attributedTitle.addAttribute(
+                .font,
+                value: UIFont.korFont(style: .medium, size: Constant.fontSize)!,
+                range: NSRange(location: .zero, length: attributedTitle.length)
+            )
+        }
 
-           let action = UIAction { [weak self] _ in
-               self?.buttonAction?()
-           }
-           button.addAction(action, for: .touchUpInside)
-           currentAction = action
-       }
-   }
+        self.button.setAttributedTitle(attributedTitle, for: .normal)
+    }
+
+    var buttonAction: (() -> Void)? {
+        didSet {
+            if let oldAction = currentAction {
+                self.button.removeAction(oldAction, for: .touchUpInside)
+            }
+            let action = UIAction { [weak self] _ in
+                guard let self = self else { return }
+                self.buttonAction?()
+            }
+            self.button.addAction(action, for: .touchUpInside)
+            self.currentAction = action
+        }
+    }
 }
-
 extension UIImage {
-   func resize(to size: CGSize) -> UIImage? {
-       UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
-       defer { UIGraphicsEndImageContext() }
-       draw(in: CGRect(origin: .zero, size: size))
-       return UIGraphicsGetImageFromCurrentImageContext()
-   }
+    func resize(to size: CGSize) -> UIImage? {
+        UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
+        defer { UIGraphicsEndImageContext() }
+        self.draw(in: CGRect(origin: .zero, size: size))
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
 }

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/FilterBottomSheetView.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/FilterBottomSheetView.swift
@@ -317,7 +317,6 @@ final class FilterBottomSheetView: UIView {
         return button
     }
 
-
     func updateMainLocationSelection(_ index: Int) {
         locationContentView.subviews.enumerated().forEach { (idx, view) in
             guard let button = view as? PPButton else { return }

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/FilterBottomSheetView.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FillterSheetView/FilterBottomSheetView.swift
@@ -1,39 +1,43 @@
-import SnapKit
 import UIKit
 
+import SnapKit
+import Then
+
 final class FilterBottomSheetView: UIView {
-    // MARK: - UI Components
-    private let containerView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .white
-        view.layer.cornerRadius = 20
-        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        view.layer.masksToBounds = true
-        return view
-    }()
+    private enum Constant {
+        static let cornerRadius: CGFloat = 20
+        static let topInset: CGFloat = 30
+        static let horizontalInset: CGFloat = 16
+        static let segmentedTopOffset: CGFloat = 16
+        static let scrollViewHeight: CGFloat = 36
+        static let categoryHeight: CGFloat = 160
+        static let balloonTopOffset: CGFloat = 16
+        static let filterChipsHeight: CGFloat = 80
+        static let buttonStackSpacing: CGFloat = 12
+        static let buttonStackHeight: CGFloat = 52
+    }
 
-    let titleLabel: PPLabel = {
-        let label = PPLabel(style: .bold, fontSize: 18, text: "보기 옵션을 선택해주세요")
-        label.textColor = .black
-        return label
-    }()
+    private let containerView = UIView().then {
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = Constant.cornerRadius
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        $0.layer.masksToBounds = true
+    }
 
-    let closeButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setImage(UIImage(named: "icon_xmark"), for: .normal)
-        button.tintColor = .black
-        return button
-    }()
+    let titleLabel = PPLabel(style: .bold, fontSize: 18, text: "보기 옵션을 선택해주세요").then {
+        $0.textColor = .black
+    }
 
-    let segmentedControl: PPSegmentedControl = {
-        return PPSegmentedControl(type: .tab, segments: ["지역", "카테고리"], selectedSegmentIndex: 0)
-    }()
+    let closeButton = UIButton(type: .system).then {
+        $0.setImage(UIImage(named: "icon_xmark"), for: .normal)
+        $0.tintColor = .black
+    }
 
-    let locationScrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.showsHorizontalScrollIndicator = false
-        return scrollView
-    }()
+    let segmentedControl = PPSegmentedControl(type: .tab, segments: ["지역", "카테고리"], selectedSegmentIndex: 0)
+
+    let locationScrollView = UIScrollView().then {
+        $0.showsHorizontalScrollIndicator = false
+    }
 
     let locationContentView = UIView()
     var categoryHeightConstraint: Constraint?
@@ -42,13 +46,13 @@ final class FilterBottomSheetView: UIView {
         let layout = UICollectionViewCompositionalLayout { section, _ in
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .estimated(26),
-                heightDimension: .estimated(36)
+                heightDimension: .estimated(Constant.scrollViewHeight)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .estimated(36)
+                heightDimension: .estimated(Constant.scrollViewHeight)
             )
             let group = NSCollectionLayoutGroup.horizontal(
                 layoutSize: groupSize,
@@ -67,35 +71,25 @@ final class FilterBottomSheetView: UIView {
 
             return section
         }
-
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clear
-        collectionView.isScrollEnabled = false
-        collectionView.register(TagSectionCell.self, forCellWithReuseIdentifier: TagSectionCell.identifiers)
-        return collectionView
+        return UICollectionView(frame: .zero, collectionViewLayout: layout).then {
+            $0.backgroundColor = .clear
+            $0.isScrollEnabled = false
+            $0.register(TagSectionCell.self, forCellWithReuseIdentifier: TagSectionCell.identifiers)
+        }
     }()
 
     let balloonBackgroundView = BalloonBackgroundView()
 
-    let resetButton: PPButton = {
-        return PPButton(style: .secondary, text: "초기화")
-    }()
+    let resetButton = PPButton(style: .secondary, text: "초기화")
+    let saveButton = PPButton(style: .primary, text: "옵션저장", disabledText: "옵션저장")
 
-    let saveButton: PPButton = {
-        return PPButton(style: .primary, text: "옵션저장", disabledText: "옵션저장")
-    }()
+    private let buttonStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = Constant.buttonStackSpacing
+        $0.distribution = .fillEqually
+    }
 
-    private let buttonStack: UIStackView = {
-        let stack = UIStackView()
-        stack.axis = .horizontal
-        stack.spacing = 12
-        stack.distribution = .fillEqually
-        return stack
-    }()
-
-    let filterChipsView: FilterChipsView = {
-        return FilterChipsView()
-    }()
+    let filterChipsView = FilterChipsView()
 
     private var balloonHeightConstraint: Constraint?
 
@@ -142,25 +136,25 @@ final class FilterBottomSheetView: UIView {
         }
 
         titleLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(16)
-            make.top.equalToSuperview().offset(30)
+            make.leading.equalToSuperview().offset(Constant.horizontalInset)
+            make.top.equalToSuperview().offset(Constant.topInset)
         }
 
         closeButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(16)
+            make.trailing.equalToSuperview().inset(Constant.horizontalInset)
             make.centerY.equalTo(titleLabel)
             make.size.equalTo(24)
         }
 
         segmentedControl.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(16)
+            make.top.equalTo(titleLabel.snp.bottom).offset(Constant.segmentedTopOffset)
             make.leading.trailing.equalToSuperview()
         }
 
         locationScrollView.snp.makeConstraints { make in
             make.top.equalTo(segmentedControl.snp.bottom).offset(20)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(36)
+            make.height.equalTo(Constant.scrollViewHeight)
         }
 
         locationContentView.snp.makeConstraints { make in
@@ -169,28 +163,28 @@ final class FilterBottomSheetView: UIView {
         }
 
         categoryCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(segmentedControl.snp.bottom).offset(16)
+            make.top.equalTo(segmentedControl.snp.bottom).offset(Constant.segmentedTopOffset)
             make.leading.trailing.equalToSuperview()
-            categoryHeightConstraint = make.height.equalTo(160).constraint
+            categoryHeightConstraint = make.height.equalTo(Constant.categoryHeight).constraint
         }
 
         balloonBackgroundView.snp.makeConstraints { make in
-            make.top.equalTo(locationScrollView.snp.bottom).offset(16)
-            make.leading.trailing.equalToSuperview().inset(16)
+            make.top.equalTo(locationScrollView.snp.bottom).offset(Constant.balloonTopOffset)
+            make.leading.trailing.equalToSuperview().inset(Constant.horizontalInset)
             balloonHeightConstraint = make.height.equalTo(0).constraint
         }
 
         filterChipsView.snp.makeConstraints { make in
             make.top.equalTo(balloonBackgroundView.snp.bottom).offset(24)
-            make.leading.trailing.equalToSuperview().inset(16)
-            make.height.equalTo(80)
+            make.leading.trailing.equalToSuperview().inset(Constant.horizontalInset)
+            make.height.equalTo(Constant.filterChipsHeight)
         }
 
         buttonStack.snp.makeConstraints { make in
             make.top.equalTo(filterChipsView.snp.bottom).offset(24)
-            make.leading.trailing.equalToSuperview().inset(16)
+            make.leading.trailing.equalToSuperview().inset(Constant.horizontalInset)
             make.bottom.equalToSuperview().inset(40)
-            make.height.equalTo(52)
+            make.height.equalTo(Constant.buttonStackHeight)
         }
     }
 
@@ -305,41 +299,44 @@ final class FilterBottomSheetView: UIView {
         let button = PPButton(
             style: .secondary,
             text: title,
-            font: .korFont(style: .medium, size: 13),
+            font: .korFont(style: isSelected ? .bold : .medium, size: 13),
             cornerRadius: 18
         )
-        button.setBackgroundColor(.w100, for: .normal)
-        button.setTitleColor(.g400, for: .normal)
+        button.setBackgroundColor(isSelected ? .blu500 : .w100, for: .normal)
+        button.setTitleColor(isSelected ? .w100 : .g400, for: .normal)
+        button.layer.borderWidth = isSelected ? 0 : 1
         button.layer.borderColor = UIColor.g200.cgColor
-        button.layer.borderWidth = 1
-
-        if isSelected {
-            button.setBackgroundColor(.blu500, for: .normal)
-            button.setTitleColor(.w100, for: .normal)
-            button.layer.borderWidth = 0
-        }
-
         button.contentEdgeInsets = UIEdgeInsets(top: 9, left: 16, bottom: 9, right: 16)
+
+        button.titleLabel?.setLineHeightText(
+            text: title,
+            font: .korFont(style: isSelected ? .bold : .medium, size: 13),
+            lineHeight: 1.2
+        )
 
         return button
     }
 
+
     func updateMainLocationSelection(_ index: Int) {
         locationContentView.subviews.enumerated().forEach { (idx, view) in
             guard let button = view as? PPButton else { return }
-            if idx == index {
-                button.setBackgroundColor(.blu500, for: .normal)
-                button.setTitleColor(.w100, for: .normal)
-                button.layer.borderWidth = 0
-                button.titleLabel?.font = .korFont(style: .bold, size: 13)
-            } else {
-                button.setBackgroundColor(.w100, for: .normal)
-                button.setTitleColor(.g400, for: .normal)
-                button.layer.borderColor = UIColor.g200.cgColor
-                button.titleLabel?.font = .korFont(style: .medium, size: 13)
-                button.layer.borderWidth = 1
-            }
+
+            let isSelected = idx == index
+            button.setBackgroundColor(isSelected ? .blu500 : .w100, for: .normal)
+            button.setTitleColor(isSelected ? .w100 : .g400, for: .normal)
+            button.layer.borderWidth = isSelected ? 0 : 1
+            button.layer.borderColor = UIColor.g200.cgColor
+
+            // 버튼의 타이틀 레이블에 setLineHeightText 적용
+            let title = button.currentTitle ?? ""
+            button.titleLabel?.setLineHeightText(
+                text: title,
+                font: .korFont(style: isSelected ? .bold : .medium, size: 13),
+                lineHeight: 1.2
+            )
         }
+
     }
 
     func updateBalloonHeight(isHidden: Bool, dynamicHeight: CGFloat = 160) {

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/MapView/MapViewController.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/MapView/MapViewController.swift
@@ -161,12 +161,10 @@ class MapViewController: BaseViewController, View, CLLocationManagerDelegate, NM
                         self.configureTooltip(for: markerToFocus, stores: storeArray)
                     }
 
-                    // 툴팁에서 선택된 스토어 업데이트
                     if let tooltipIndex = storeArray.firstIndex(where: { $0.id == store.id }) {
                         (self.currentTooltipView as? MarkerTooltipView)?.selectStore(at: tooltipIndex)
                     }
                 } else {
-                    // 단일 마커면 기존 툴팁 제거
                     self.currentTooltipView?.removeFromSuperview()
                     self.currentTooltipView = nil
                 }


### PR DESCRIPTION
## 📌 이슈

- #135 

## ✅ 작업 사항

- [x] `UIButton`/`PPButton`의 기본 `intrinsicContentSize`로는 볼드 폰트의 ascender+descender 높이를 충분히 담지 못하는 문제 확인  
- [x] `NSMutableAttributedString`에 `.baselineOffset` 속성(`-1`)을 추가하여 약간의 트릭(?) 텍스트를 살짝 아래로 이동시켜 잘림 방지  
- [x] 버튼 생성 및 상태별 UI 설정을 `Then` 체이닝(`.then {…}`, `.do {…}`)으로 가독성 개선  
- [x] 각종 매직 넘버(`inset`, `fontSize`, `baselineOffset`, `checkIconSize` 등)를 `enum Constant`로 추출  

## 🚀 테스트 방식

 Filter Sheet 열어 “지역 태그” 버튼 영역 확인  
2. 기본(비선택) 상태와 탭(선택) 상태 모두에서  
   - 볼드 폰트(선택 상태) 적용 시 위쪽이 잘리지 않는지  
   - 체크 아이콘이 정상 크기로 나오는지  
4. Accessibility → Bold Text 켜고 동일 확인  
5. Simulator와 실제 기기(iOS 16, 17) 양쪽에서 검증  

<img width="336" alt="스크린샷 2025-05-05 오후 6 37 08" src="https://github.com/user-attachments/assets/68b94273-ec79-4a52-9af0-6e27ecd3c55e" />

## 👀 ETC (추후 개발해야 할 것, 참고자료 등) ->

- Apple Doc: [NSAttributedString.Key.baselineOffset](https://developer.apple.com/documentation/foundation/nsattributedstring/key/baselineoffset)  
 