### PR TITLE
풀스크린맵뷰 애니메이션 제거와 어드민페이지 수정화면 정상화

### DIFF
--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Admin/AdminViewController.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Admin/AdminViewController.swift
@@ -176,7 +176,7 @@ final class AdminViewController: BaseViewController, View {
         adminUseCase.fetchStoreDetail(id: store.id)
             .observe(on: MainScheduler.instance)
             .subscribe(
-                onNext: { [weak self] storeDetail in
+                onNext: { [weak self] _ in
                     guard let self = self else { return }
                     let registerVC = PopUpStoreRegisterViewController(
                         nickname: self.nickname,

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Admin/AdminViewController.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Admin/AdminViewController.swift
@@ -178,24 +178,15 @@ final class AdminViewController: BaseViewController, View {
             .subscribe(
                 onNext: { [weak self] storeDetail in
                     guard let self = self else { return }
-                    let updateParams = UpdateStoreParams(
-                        id: storeDetail.id,
-                        name: storeDetail.name,
-                        categoryId: storeDetail.categoryId,
-                        desc: storeDetail.description,
-                        address: storeDetail.address,
-                        startDate: storeDetail.startDate,
-                        endDate: storeDetail.endDate,
-                        mainImageUrl: storeDetail.mainImageUrl,
-                        imageUrlList: storeDetail.images.map { $0.imageUrl },
-                        imagesToDelete: [],
-                        latitude: storeDetail.latitude,
-                        longitude: storeDetail.longitude,
-                        markerTitle: storeDetail.markerTitle,
-                        markerSnippet: storeDetail.markerSnippet,
-                        startDateBeforeEndDate: true
+                    let registerVC = PopUpStoreRegisterViewController(
+                        nickname: self.nickname,
+                        editingStore: store
                     )
-                    let registerVC = PopUpStoreRegisterViewController(nickname: self.nickname)
+
+                    registerVC.completionHandler = { [weak self] in
+                        self?.reactor?.action.onNext(.reloadData)
+                    }
+
                     self.navigationController?.pushViewController(registerVC, animated: true)
                 },
                 onError: { [weak self] error in
@@ -206,7 +197,6 @@ final class AdminViewController: BaseViewController, View {
     }
 
     private func deleteStore(_ store: AdminStore) {
-        // 먼저 스토어 상세 정보를 가져와 모든 이미지 URL을 확인
         adminUseCase.fetchStoreDetail(id: store.id)
             .observe(on: MainScheduler.instance)
             .subscribe(

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FindMap/MapGuideView/FullScreenMapViewController.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Map/FindMap/MapGuideView/FullScreenMapViewController.swift
@@ -106,8 +106,8 @@ class FullScreenMapViewController: MapViewController {
         let position = NMGLatLng(lat: store.latitude, lng: store.longitude)
 
         let cameraUpdate = NMFCameraUpdate(scrollTo: position, zoomTo: 15.0)
-        cameraUpdate.animation = .easeIn
-        cameraUpdate.animationDuration = 0.3
+        mainView.mapView.cancelTransitions()
+        cameraUpdate.animation = .none
         mainView.mapView.moveCamera(cameraUpdate)
 
         if let existingMarker = initialMarker {
@@ -210,8 +210,8 @@ class FullScreenMapViewController: MapViewController {
         mainView.setStoreCardHidden(false, animated: true)
 
         let cameraUpdate = NMFCameraUpdate(scrollTo: marker.position, zoomTo: 15.0)
-        cameraUpdate.animation = .easeIn
-        cameraUpdate.animationDuration = 0.3
+        mainView.mapView.cancelTransitions()
+        cameraUpdate.animation = .none
         mainView.mapView.moveCamera(cameraUpdate)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in


### PR DESCRIPTION
## 📌 이슈
- #139 
## ✅ 작업 사항
- [x] 풀스크린 맵뷰에서 애니매이션이 더이상 발생하지않도록 none 으로 처리
- [x] 어드민페이지의 수정화면에서 이전에 기입한 내용이 올라갈수있도록 수정

## 🚀 테스트 방식

실기기와 시뮬레이션 교차 검증 확인