### PR TITLE
[REFACTOR] 레이아웃 팩토리 개선 및 빌더 도입

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,93 @@
+language: ko-KR # 언어 설정
+
+early_access: true # 미리보기 기능 활성화
+enable_free_tier: true # 프리 티어 활성화
+auto_resolve_threads: false # 자동 해결 비활성화
+
+reviews:
+  profile: chill
+  request_changes_workflow: true
+  high_level_summary: true # 리뷰에 대해 요약(high-level summary)를 자동 작성
+  high_level_summary_placeholder: '@coderabbitai 요약'
+  auto_title_placeholder: '@coderabbitai'
+  poem: true
+  review_status: true # PR 리뷰 상태를 리뷰 요약란에 표시
+  collapse_walkthrough: false # 리뷰 단계 설명을 기본적으로 접지 않음
+
+  abort_on_close: true # PR이 닫히면 리뷰 수행을 중단(abort)
+
+
+  auto_review:
+    enabled: true # 자동 리뷰 기능을 활성화
+    auto_incremental_review: true # 커밋이 추가될 때마다 변경 사항에 대해서만 자동 수행
+    ignore_title_keywords: [] # PR 제목에 포함되면 리뷰를 건너뛰는 키워드 목록
+    labels: [] # 특정 라벨이 붙은 PR만 자동 리뷰 대상
+    drafts: false # Draft 상태인 PR은 자동 리뷰 대상에서 제외(false면 제외)
+    base_branches: [] # 특정 브랜치만 리뷰하도록
+
+  tools:
+    shellcheck: # 셸 스크립트 문법 및 보안 검사
+      enabled: true
+    ruff: # Python 코드 스타일 검사기
+      enabled: true
+    markdownlint: # 마크다운 문법 검사
+      enabled: true
+    github-checks: # GitHub 체크 연동 + 타임아웃(ms 단위)
+      enabled: true
+      timeout_ms: 90000
+    languagetool: # 맞춤법, 문법 검사
+      enabled: true
+      disabled_rules:
+        - EN_UNPAIRED_BRACKETS
+        - EN_UNPAIRED_QUOTES
+      disabled_categories:
+        - TYPOS
+        - TYPOGRAPHY
+        - CASING
+      enabled_only: false
+      level: default
+      enabled_rules: []
+      enabled_categories: []
+    biome: # JavaScript/TypeScript 정적 분석
+      enabled: true
+    hadolint: # Dockerfile 코드 스타일 검사
+      enabled: true
+    swiftlint: # Swift 코드 스타일 검사
+      enabled: true
+    phpstan: # PHP 정적 분석
+      enabled: true
+      level: default
+    golangci-lint: # Go 코드 스타일 검사
+      enabled: true
+    yamllint: # YAML 형식 검사
+      enabled: true
+    gitleaks: # Git 시크릿 노출 탐지
+      enabled: true
+    checkov: # 인프라 보안 검사
+      enabled: true
+    ast-grep: # AST 기반 코드 패턴 검사
+      packages: []
+      rule_dirs: []
+      util_dirs: []
+      essential_rules: true
+
+# CodeRabbit AI 챗 기능을 사용 가능하게 하고,
+# 한 번에 처리 가능한 토큰 수를 최대 4096으로 제한
+chat:
+  enabled: true
+  max_token_length: 4096
+
+
+# 지식 기반에 사용할 학습 범위를 지정하십시오.
+# 'Local' - Repository
+# 'Global'- Organization
+# 'Auto' - Repository(users public) + Organization(private)
+knowledge_base:
+  web_search: # AI 웹 검색 허용
+    enabled: true
+  learnings: # 학습 범위 설정 (local, global, auto)
+    scope: local
+  issues: # 이슈 자동 참조 범위 설정 (local, global, auto)
+    scope: auto
+  jira:
+    project_keys: []

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Cursor
+Poppool/buildServer.json

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Cursor
+Poppool/buildServer.json
+.vscode/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,5 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 # Cursor
-Poppool/buildServer.json
+**/buildServer.json
 .vscode/*
-

--- a/Poppool/CoreLayer/Infrastructure/Infrastructure/Extension/Collection+.swift
+++ b/Poppool/CoreLayer/Infrastructure/Infrastructure/Extension/Collection+.swift
@@ -4,4 +4,4 @@ public extension Collection {
     subscript(safe index: Index) -> Element? {
         return indices.contains(index) ? self[index] : nil
     }
-} 
+}

--- a/Poppool/CoreLayer/Infrastructure/Infrastructure/Extension/Collection+.swift
+++ b/Poppool/CoreLayer/Infrastructure/Infrastructure/Extension/Collection+.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public extension Collection {
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+} 

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/CollectionLayoutBuilder.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/CollectionLayoutBuilder.swift
@@ -1,0 +1,185 @@
+import UIKit
+
+public final class CollectionLayoutBuilder {
+    private var itemSize: NSCollectionLayoutSize?
+    private var groupSize: NSCollectionLayoutSize?
+    private var numberOfItemsPerGroup: Int = 1
+    private var interItemSpacing: NSCollectionLayoutSpacing?
+    private var section: NSCollectionLayoutSection?
+    private var headerItem: NSCollectionLayoutBoundarySupplementaryItem?
+    
+    public init() { }
+
+    public init(section existingSection: NSCollectionLayoutSection) {
+        self.section = existingSection
+    }
+
+    @discardableResult
+    public func item(
+        width: NSCollectionLayoutDimension,
+        height: NSCollectionLayoutDimension
+    ) -> Self {
+        itemSize = NSCollectionLayoutSize(
+            widthDimension: width,
+            heightDimension: height
+        )
+
+        return self
+    }
+    
+    @discardableResult
+    public func group(
+        width: NSCollectionLayoutDimension,
+        height: NSCollectionLayoutDimension
+    ) -> Self {
+        groupSize = NSCollectionLayoutSize(
+            widthDimension: width,
+            heightDimension: height
+        )
+
+        return self
+    }
+    
+    @discardableResult
+    public func numberOfItemsPerGroup(_ count: Int) -> Self {
+        numberOfItemsPerGroup = count
+
+        return self
+    }
+    
+    @discardableResult
+    public func itemSpacing(_ spacing: CGFloat) -> Self {
+        interItemSpacing = .fixed(spacing)
+
+        return self
+    }
+    
+    @discardableResult
+    public func withContentInsets(
+        top: CGFloat = 0,
+        leading: CGFloat = 0,
+        bottom: CGFloat = 0,
+        trailing: CGFloat = 0
+    ) -> Self {
+        section?.contentInsets = NSDirectionalEdgeInsets(
+            top: top,
+            leading: leading,
+            bottom: bottom,
+            trailing: trailing
+        )
+
+        return self
+    }
+    
+    @discardableResult
+    public func composeSection(_ axis: UIAxis) -> Self {
+        guard let itemSize, let groupSize else {
+            fatalError("Item and Group must be set before creating section")
+        }
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        var group: NSCollectionLayoutGroup!
+
+        switch axis {
+        case .vertical:
+            group = NSCollectionLayoutGroup.vertical(
+                layoutSize: groupSize,
+                subitems: Array(repeating: item, count: numberOfItemsPerGroup)
+            )
+
+        case .horizontal:
+            group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: groupSize,
+                subitems: Array(repeating: item, count: numberOfItemsPerGroup)
+            )
+
+        default: fatalError("Can't compose section to selected axis")
+        }
+        
+        if let interItemSpacing {
+            group.interItemSpacing = interItemSpacing
+        }
+        
+        section = NSCollectionLayoutSection(group: group)
+
+        return self
+    }
+    
+    @discardableResult
+    public func header(
+        elementKind: String,
+        width: NSCollectionLayoutDimension = .fractionalWidth(1.0),
+        height: NSCollectionLayoutDimension = .fractionalHeight(1.0),
+        alignment: NSRectAlignment = .top
+    ) -> Self {
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: width,
+            heightDimension: height
+        )
+        
+        headerItem = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: elementKind,
+            alignment: alignment
+        )
+        
+        if let headerItem {
+            section?.boundarySupplementaryItems = [headerItem]
+        }
+        
+        return self
+    }
+    
+    @discardableResult
+    public func withScrollingBehavior(_ behavior: UICollectionLayoutSectionOrthogonalScrollingBehavior) -> Self {
+        section?.orthogonalScrollingBehavior = behavior
+
+        return self
+    }
+    
+    @discardableResult
+    public func groupSpacing(_ spacing: CGFloat) -> Self {
+        section?.interGroupSpacing = spacing
+
+        return self
+    }
+    
+    @discardableResult
+    public func modifySection(_ modifier: (NSCollectionLayoutSection) -> Void) -> Self {
+        if let section = self.section {
+            modifier(section)
+        }
+        return self
+    }
+    
+    @discardableResult
+    public func withExistingHeader(_ headerItem: NSCollectionLayoutBoundarySupplementaryItem) -> Self {
+        self.headerItem = headerItem
+        
+        if let section = self.section {
+            section.boundarySupplementaryItems = [headerItem]
+        }
+        
+        return self
+    }
+
+    @discardableResult
+    public func header(_ headerItems: [NSCollectionLayoutBoundarySupplementaryItem]) -> Self {
+        if let section = self.section {
+            section.boundarySupplementaryItems = headerItems
+        }
+        
+        return self
+    }
+    
+    public func build() -> NSCollectionLayoutSection {
+        guard let section else { fatalError("Section must be created before building") }
+        return section
+    }
+    
+    public func buildHeader() -> NSCollectionLayoutBoundarySupplementaryItem {
+        guard let headerItem else { fatalError("Header must be created before building") }
+        return headerItem
+    }
+} 

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/CollectionLayoutBuilder.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/CollectionLayoutBuilder.swift
@@ -7,7 +7,7 @@ public final class CollectionLayoutBuilder {
     private var interItemSpacing: NSCollectionLayoutSpacing?
     private var section: NSCollectionLayoutSection?
     private var headerItem: NSCollectionLayoutBoundarySupplementaryItem?
-    
+
     public init() { }
 
     public init(section existingSection: NSCollectionLayoutSection) {
@@ -26,7 +26,7 @@ public final class CollectionLayoutBuilder {
 
         return self
     }
-    
+
     @discardableResult
     public func group(
         width: NSCollectionLayoutDimension,
@@ -39,21 +39,21 @@ public final class CollectionLayoutBuilder {
 
         return self
     }
-    
+
     @discardableResult
     public func numberOfItemsPerGroup(_ count: Int) -> Self {
         numberOfItemsPerGroup = count
 
         return self
     }
-    
+
     @discardableResult
     public func itemSpacing(_ spacing: CGFloat) -> Self {
         interItemSpacing = .fixed(spacing)
 
         return self
     }
-    
+
     @discardableResult
     public func withContentInsets(
         top: CGFloat = 0,
@@ -70,13 +70,13 @@ public final class CollectionLayoutBuilder {
 
         return self
     }
-    
+
     @discardableResult
     public func composeSection(_ axis: UIAxis) -> Self {
         guard let itemSize, let groupSize else {
             fatalError("Item and Group must be set before creating section")
         }
-        
+
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         var group: NSCollectionLayoutGroup!
@@ -96,16 +96,16 @@ public final class CollectionLayoutBuilder {
 
         default: fatalError("Can't compose section to selected axis")
         }
-        
+
         if let interItemSpacing {
             group.interItemSpacing = interItemSpacing
         }
-        
+
         section = NSCollectionLayoutSection(group: group)
 
         return self
     }
-    
+
     @discardableResult
     public func header(
         elementKind: String,
@@ -117,34 +117,34 @@ public final class CollectionLayoutBuilder {
             widthDimension: width,
             heightDimension: height
         )
-        
+
         headerItem = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: headerSize,
             elementKind: elementKind,
             alignment: alignment
         )
-        
+
         if let headerItem {
             section?.boundarySupplementaryItems = [headerItem]
         }
-        
+
         return self
     }
-    
+
     @discardableResult
     public func withScrollingBehavior(_ behavior: UICollectionLayoutSectionOrthogonalScrollingBehavior) -> Self {
         section?.orthogonalScrollingBehavior = behavior
 
         return self
     }
-    
+
     @discardableResult
     public func groupSpacing(_ spacing: CGFloat) -> Self {
         section?.interGroupSpacing = spacing
 
         return self
     }
-    
+
     @discardableResult
     public func modifySection(_ modifier: (NSCollectionLayoutSection) -> Void) -> Self {
         if let section = self.section {
@@ -152,15 +152,15 @@ public final class CollectionLayoutBuilder {
         }
         return self
     }
-    
+
     @discardableResult
     public func withExistingHeader(_ headerItem: NSCollectionLayoutBoundarySupplementaryItem) -> Self {
         self.headerItem = headerItem
-        
+
         if let section = self.section {
             section.boundarySupplementaryItems = [headerItem]
         }
-        
+
         return self
     }
 
@@ -169,17 +169,17 @@ public final class CollectionLayoutBuilder {
         if let section = self.section {
             section.boundarySupplementaryItems = headerItems
         }
-        
+
         return self
     }
-    
+
     public func build() -> NSCollectionLayoutSection {
         guard let section else { fatalError("Section must be created before building") }
         return section
     }
-    
+
     public func buildHeader() -> NSCollectionLayoutBoundarySupplementaryItem {
         guard let headerItem else { fatalError("Header must be created before building") }
         return headerItem
     }
-} 
+}

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/CollectionLayoutProvidable.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/CollectionLayoutProvidable.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+public protocol CollectionLayoutProvidable {
+    func makeLayout() -> NSCollectionLayoutSection
+}

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/GridCollectionLayoutProvider.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/GridCollectionLayoutProvider.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+public struct GridCollectionLayoutProvider: CollectionLayoutProvidable {
+    public init() { }
+    
+    public func makeLayout() -> NSCollectionLayoutSection {
+        // Item
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(0.5),
+            heightDimension: .absolute(249)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        // Group
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(249)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item, item]
+        )
+        group.interItemSpacing = .fixed(16)
+
+        // Section
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 0, trailing: 20)
+        section.interGroupSpacing = 24
+
+        return section
+    }
+} 

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/GridCollectionLayoutProvider.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/GridCollectionLayoutProvider.swift
@@ -4,29 +4,14 @@ public struct GridCollectionLayoutProvider: CollectionLayoutProvidable {
     public init() { }
     
     public func makeLayout() -> NSCollectionLayoutSection {
-        // Item
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(0.5),
-            heightDimension: .absolute(249)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        // Group
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(249)
-        )
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitems: [item, item]
-        )
-        group.interItemSpacing = .fixed(16)
-
-        // Section
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 0, trailing: 20)
-        section.interGroupSpacing = 24
-
-        return section
+        return CollectionLayoutBuilder()
+            .item(width: .fractionalWidth(0.5), height: .absolute(249))
+            .group(width: .fractionalWidth(1.0), height: .absolute(249))
+            .numberOfItemsPerGroup(2)
+            .itemSpacing(16)
+            .composeSection(.horizontal)
+            .withContentInsets(top: 16, leading: 20, bottom: 0, trailing: 20)
+            .groupSpacing(24)
+            .build()
     }
-} 
+}

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/GridCollectionLayoutProvider.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/GridCollectionLayoutProvider.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct GridCollectionLayoutProvider: CollectionLayoutProvidable {
     public init() { }
-    
+
     public func makeLayout() -> NSCollectionLayoutSection {
         return CollectionLayoutBuilder()
             .item(width: .fractionalWidth(0.5), height: .absolute(249))

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/HeaderLayoutProvidable.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/HeaderLayoutProvidable.swift
@@ -2,4 +2,4 @@ import UIKit
 
 public protocol HeaderLayoutProvidable {
     func makeHeaderLayout(_ elementKind: String) -> NSCollectionLayoutBoundarySupplementaryItem
-} 
+}

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/HeaderLayoutProvidable.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/HeaderLayoutProvidable.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+public protocol HeaderLayoutProvidable {
+    func makeHeaderLayout(_ elementKind: String) -> NSCollectionLayoutBoundarySupplementaryItem
+} 

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public struct TagCollectionLayoutProvider: CollectionLayoutProvidable, HeaderLayoutProvidable {
     public init() { }
-    
+
     public func makeLayout() -> NSCollectionLayoutSection {
         return CollectionLayoutBuilder()
             .item(width: .estimated(100), height: .absolute(31))
@@ -12,10 +12,10 @@ public struct TagCollectionLayoutProvider: CollectionLayoutProvidable, HeaderLay
             .groupSpacing(6)
             .build()
     }
-    
+
     public func makeHeaderLayout(_ elementKind: String) -> NSCollectionLayoutBoundarySupplementaryItem {
         return CollectionLayoutBuilder()
             .header(elementKind: elementKind, height: .absolute(24))
             .buildHeader()
     }
-} 
+}

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
@@ -1,0 +1,51 @@
+import UIKit
+
+public struct TagCollectionLayoutProvider: CollectionLayoutProvidable, HeaderLayoutProvidable {
+    public init() { }
+    
+    public func makeLayout() -> NSCollectionLayoutSection {
+        // Item
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .estimated(100),
+            heightDimension: .absolute(31)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        // Group
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .estimated(100),
+            heightDimension: .estimated(31)
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+
+        // Section
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = 6
+        
+        return section
+    }
+    
+    public func makeHeaderLayout(_ elementKind: String) -> NSCollectionLayoutBoundarySupplementaryItem {
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(24)
+        )
+        return NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: elementKind,
+            alignment: .top
+        )
+    }
+    
+    public func configureSectionInsets(_ section: NSCollectionLayoutSection, isRecentSearch: Bool) {
+        if isRecentSearch {
+            section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 48, trailing: 20)
+        } else {
+            section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
+        }
+    }
+} 

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
@@ -4,40 +4,18 @@ public struct TagCollectionLayoutProvider: CollectionLayoutProvidable, HeaderLay
     public init() { }
     
     public func makeLayout() -> NSCollectionLayoutSection {
-        // Item
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .estimated(100),
-            heightDimension: .absolute(31)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        // Group
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .estimated(100),
-            heightDimension: .estimated(31)
-        )
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitems: [item]
-        )
-
-        // Section
-        let section = NSCollectionLayoutSection(group: group)
-        section.orthogonalScrollingBehavior = .continuous
-        section.interGroupSpacing = 6
-        
-        return section
+        return CollectionLayoutBuilder()
+            .item(width: .estimated(100), height: .absolute(31))
+            .group(width: .estimated(100), height: .estimated(31))
+            .composeSection(.vertical)
+            .withScrollingBehavior(.continuous)
+            .groupSpacing(6)
+            .build()
     }
     
     public func makeHeaderLayout(_ elementKind: String) -> NSCollectionLayoutBoundarySupplementaryItem {
-        let headerSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(24)
-        )
-        return NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: headerSize,
-            elementKind: elementKind,
-            alignment: .top
-        )
+        return CollectionLayoutBuilder()
+            .header(elementKind: elementKind, height: .absolute(24))
+            .buildHeader()
     }
 } 

--- a/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
+++ b/Poppool/PresentationLayer/DesignSystem/DesignSystem/Components/Layout/TagCollectionLayoutProvider.swift
@@ -40,12 +40,4 @@ public struct TagCollectionLayoutProvider: CollectionLayoutProvidable, HeaderLay
             alignment: .top
         )
     }
-    
-    public func configureSectionInsets(_ section: NSCollectionLayoutSection, isRecentSearch: Bool) {
-        if isRecentSearch {
-            section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 48, trailing: 20)
-        } else {
-            section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
-        }
-    }
 } 

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature.xcodeproj/project.pbxproj
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0506BE882DD79A6C006CDEDE /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 0506BE872DD79A6C006CDEDE /* RxCocoa */; };
 		052413092DCF7DA100C42E2D /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 052413082DCF7DA100C42E2D /* DesignSystem.framework */; };
 		0524130A2DCF7DA100C42E2D /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 052413082DCF7DA100C42E2D /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		054A96202DCE38B500C0DD58 /* SearchFeatureInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05734BF52DCDA6B90093825D /* SearchFeatureInterface.framework */; };
@@ -40,7 +41,6 @@
 		05CFFBF42DCB908B0051129F /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05EC23422DC49AA200C761A5 /* DesignSystem.framework */; };
 		05CFFBF52DCB908B0051129F /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 05EC23422DC49AA200C761A5 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		05CFFBF72DCB90A10051129F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 05CFFBF62DCB90A10051129F /* SnapKit */; };
-		05EC233C2DC49A7600C761A5 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 05EC233B2DC49A7600C761A5 /* RxCocoa */; };
 		05EC233E2DC49A7600C761A5 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 05EC233D2DC49A7600C761A5 /* RxSwift */; };
 		05EC23412DC49A8B00C761A5 /* ReactorKit in Frameworks */ = {isa = PBXBuildFile; productRef = 05EC23402DC49A8B00C761A5 /* ReactorKit */; };
 		05EC23472DC49AA800C761A5 /* DomainInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05EC23462DC49AA800C761A5 /* DomainInterface.framework */; };
@@ -178,6 +178,7 @@
 			files = (
 				05734C442DCDF7240093825D /* PresentationInterface.framework in Frameworks */,
 				05EC2AE92DC7C07400C761A5 /* RxRelay in Frameworks */,
+				0506BE882DD79A6C006CDEDE /* RxCocoa in Frameworks */,
 				05EC285F2DC5C1CF00C761A5 /* DesignSystem.framework in Frameworks */,
 				05EC23472DC49AA800C761A5 /* DomainInterface.framework in Frameworks */,
 				05EC234B2DC49AB400C761A5 /* Then in Frameworks */,
@@ -185,7 +186,6 @@
 				05EC234E2DC49AC100C761A5 /* SnapKit in Frameworks */,
 				05734C082DCDA7D20093825D /* SearchFeatureInterface.framework in Frameworks */,
 				05EC23412DC49A8B00C761A5 /* ReactorKit in Frameworks */,
-				05EC233C2DC49A7600C761A5 /* RxCocoa in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -306,12 +306,12 @@
 			);
 			name = SearchFeature;
 			packageProductDependencies = (
-				05EC233B2DC49A7600C761A5 /* RxCocoa */,
 				05EC233D2DC49A7600C761A5 /* RxSwift */,
 				05EC23402DC49A8B00C761A5 /* ReactorKit */,
 				05EC234A2DC49AB400C761A5 /* Then */,
 				05EC234D2DC49AC100C761A5 /* SnapKit */,
 				05EC2AE82DC7C07400C761A5 /* RxRelay */,
+				0506BE872DD79A6C006CDEDE /* RxCocoa */,
 			);
 			productName = SearchFeature;
 			productReference = 0516336D2DC457A900A6C0D1 /* SearchFeature.framework */;
@@ -938,6 +938,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0506BE872DD79A6C006CDEDE /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 05EC233A2DC49A7600C761A5 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
 		054A96252DCE38E900C0DD58 /* Tabman */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 054A96242DCE38E900C0DD58 /* XCRemoteSwiftPackageReference "Tabman" */;
@@ -972,11 +977,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 05EC234C2DC49AC100C761A5 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
-		};
-		05EC233B2DC49A7600C761A5 /* RxCocoa */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 05EC233A2DC49A7600C761A5 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxCocoa;
 		};
 		05EC233D2DC49A7600C761A5 /* RxSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
@@ -1,104 +1,78 @@
 import UIKit
+
 import DesignSystem
 
 // MARK: - Layout
 struct PopupSearchLayoutFactory {
     private let tagLayoutProvider = TagCollectionLayoutProvider()
     private let gridLayoutProvider = GridCollectionLayoutProvider()
-    
+
     private var sectionProvider: ((Int) -> PopupSearchSection?)?
-    
+
     mutating func setSectionProvider(_ provider: @escaping (Int) -> PopupSearchSection?) {
         self.sectionProvider = provider
     }
 
     func makeCollectionViewLayout() -> UICollectionViewLayout {
-        return UICollectionViewCompositionalLayout {
-            sectionIndex,
-            environment -> NSCollectionLayoutSection? in
+        return UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
+
             guard let sectionType = sectionProvider?(sectionIndex) else { return nil }
 
             switch sectionType {
             case .recentSearch:
-                let layout = self.tagLayoutProvider.makeLayout()
-                layout.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 48, trailing: 20)
-                layout.boundarySupplementaryItems = [
-                    self.tagLayoutProvider.makeHeaderLayout(
-                        PopupSearchView.SectionHeaderKind.recentSearch.rawValue
-                    )
-                ]
-                return layout
-                
+                return makeRecentSearchSectionLayout()
+
             case .category:
-                let layout = self.tagLayoutProvider.makeLayout()
-                layout.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
-                layout.boundarySupplementaryItems = [
-                    self.tagLayoutProvider.makeHeaderLayout(
-                        PopupSearchView.SectionHeaderKind.category.rawValue
-                    )
-                ]
-                return layout
-                
+                return makeCategorySectionLayout()
+
             case .searchResultHeader:
                 return makeSearchResultHeaderSectionLayout()
-                
+
             case .searchResult:
                 return self.gridLayoutProvider.makeLayout()
-                
+
             case .searchResultEmpty:
                 return makeSearchResultEmptySectionLayout()
             }
         }
     }
-    
+
+    private func makeRecentSearchSectionLayout() -> NSCollectionLayoutSection {
+
+        return CollectionLayoutBuilder(section: tagLayoutProvider.makeLayout())
+            .withContentInsets(top: 16, leading: 20, bottom: 48, trailing: 20)
+            .header([self.tagLayoutProvider.makeHeaderLayout(
+                PopupSearchView.SectionHeaderKind.recentSearch.rawValue
+            )])
+            .build()
+    }
+
+    private func makeCategorySectionLayout() -> NSCollectionLayoutSection {
+
+        return CollectionLayoutBuilder(section: tagLayoutProvider.makeLayout())
+            .withContentInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
+            .header([
+                tagLayoutProvider.makeHeaderLayout(PopupSearchView.SectionHeaderKind.category.rawValue)
+            ])
+            .build()
+    }
+
     private func makeSearchResultHeaderSectionLayout() -> NSCollectionLayoutSection {
-        // Item
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(22)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-        // Group
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(22)
-        )
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitems: [item]
-        )
-
-        // Section
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20)
-
-        return section
+        return CollectionLayoutBuilder()
+            .item(width: .fractionalWidth(1.0), height: .estimated(22))
+            .group(width: .fractionalWidth(1.0), height: .estimated(22))
+            .composeSection(.horizontal)
+            .withContentInsets(top: 0, leading: 20, bottom: 0, trailing: 20)
+            .build()
     }
 
     private func makeSearchResultEmptySectionLayout() -> NSCollectionLayoutSection {
-        // Item
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalHeight(1.0)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-        // Group
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .fractionalHeight(1.0)
-        )
-
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: groupSize,
-            subitems: [item]
-        )
-
-        // Section
-        let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 0, trailing: 20)
-
-        return section
+        return CollectionLayoutBuilder()
+            .item(width: .fractionalWidth(1.0), height: .fractionalHeight(1.0))
+            .group(width: .fractionalWidth(1.0), height: .fractionalHeight(1.0))
+            .composeSection(.vertical)
+            .build()
     }
 }

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 // MARK: - Layout
-final class PopupSearchLayoutFactory {
 
     func makeCollectionViewLayout(
         dataSourceProvider: @escaping () -> UICollectionViewDiffableDataSource<PopupSearchSection, PopupSearchView.SectionItem>?
@@ -9,6 +8,7 @@ final class PopupSearchLayoutFactory {
         return UICollectionViewCompositionalLayout(sectionProvider: { [weak self] sectionIndex, _ -> NSCollectionLayoutSection? in
             guard let self = self,
                   let dataSource = dataSourceProvider() else { return nil }
+struct PopupSearchLayoutFactory {
 
            // sectionIndex를 사용하여 현재 dataSource에서 Section 타입을 가져옴
            guard sectionIndex < dataSource.snapshot().numberOfSections,

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
@@ -13,23 +13,29 @@ struct PopupSearchLayoutFactory {
     }
 
     func makeCollectionViewLayout() -> UICollectionViewLayout {
-        return UICollectionViewCompositionalLayout { sectionIndex, environment -> NSCollectionLayoutSection? in
+        return UICollectionViewCompositionalLayout {
+            sectionIndex,
+            environment -> NSCollectionLayoutSection? in
             guard let sectionType = sectionProvider?(sectionIndex) else { return nil }
 
             switch sectionType {
             case .recentSearch:
                 let layout = self.tagLayoutProvider.makeLayout()
-                self.tagLayoutProvider.configureSectionInsets(layout, isRecentSearch: true)
+                layout.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 48, trailing: 20)
                 layout.boundarySupplementaryItems = [
-                    self.tagLayoutProvider.makeHeaderLayout(PopupSearchView.SectionHeaderKind.recentSearch.rawValue)
+                    self.tagLayoutProvider.makeHeaderLayout(
+                        PopupSearchView.SectionHeaderKind.recentSearch.rawValue
+                    )
                 ]
                 return layout
                 
             case .category:
                 let layout = self.tagLayoutProvider.makeLayout()
-                self.tagLayoutProvider.configureSectionInsets(layout, isRecentSearch: false)
+                layout.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
                 layout.boundarySupplementaryItems = [
-                    self.tagLayoutProvider.makeHeaderLayout(PopupSearchView.SectionHeaderKind.category.rawValue)
+                    self.tagLayoutProvider.makeHeaderLayout(
+                        PopupSearchView.SectionHeaderKind.category.rawValue
+                    )
                 ]
                 return layout
                 

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
@@ -4,7 +4,7 @@ import UIKit
 final class PopupSearchLayoutFactory {
 
     func makeCollectionViewLayout(
-        dataSourceProvider: @escaping () -> UICollectionViewDiffableDataSource<PopupSearchView.Section, PopupSearchView.SectionItem>?
+        dataSourceProvider: @escaping () -> UICollectionViewDiffableDataSource<PopupSearchSection, PopupSearchView.SectionItem>?
     ) -> UICollectionViewLayout {
         return UICollectionViewCompositionalLayout(sectionProvider: { [weak self] sectionIndex, _ -> NSCollectionLayoutSection? in
             guard let self = self,

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
@@ -25,12 +25,10 @@ final class PopupSearchLayoutFactory {
                 return makeSearchResultHeaderSectionLayout()
 
             case .searchResult:
-                let sectionSnapshot = dataSource.snapshot(for: sectionType)
-                let hasEmptyItem = sectionSnapshot.items.contains { item in
-                    if case .searchResultEmptyItem = item { return true }
-                    return false
-                }
-                return makeSearchResultSectionLayout(hasEmptyItem: hasEmptyItem)
+                return makeSearchResultSectionLayout()
+
+            case .searchResultEmpty:
+                return makeSearchResultEmptySectionLayout()
             }
         })
     }
@@ -95,12 +93,10 @@ final class PopupSearchLayoutFactory {
         return section
     }
 
-    func makeSearchResultSectionLayout(hasEmptyItem: Bool) -> NSCollectionLayoutSection {
-        let itemWidth: NSCollectionLayoutDimension = hasEmptyItem ? .fractionalWidth(1.0) : .fractionalWidth(0.5)
-
+    func makeSearchResultSectionLayout() -> NSCollectionLayoutSection {
         // Item
         let itemSize = NSCollectionLayoutSize(
-            widthDimension: itemWidth,
+            widthDimension: .fractionalWidth(0.5),
             heightDimension: .absolute(249)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -120,6 +116,33 @@ final class PopupSearchLayoutFactory {
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 0, trailing: 20)
         section.interGroupSpacing = 24
+
+        return section
+    }
+
+    func makeSearchResultEmptySectionLayout() -> NSCollectionLayoutSection {
+
+        // Item
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        // Group
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+
+        // Section
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 0, trailing: 20)
 
         return section
     }

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Factory/PopupSearchLayoutFactory.swift
@@ -27,7 +27,7 @@ final class PopupSearchLayoutFactory {
             case .searchResult:
                 let sectionSnapshot = dataSource.snapshot(for: sectionType)
                 let hasEmptyItem = sectionSnapshot.items.contains { item in
-                    if case .searchResultEmptyTitle = item { return true }
+                    if case .searchResultEmptyItem = item { return true }
                     return false
                 }
                 return makeSearchResultSectionLayout(hasEmptyItem: hasEmptyItem)

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
@@ -438,7 +438,9 @@ private extension PopupSearchReactor {
     }
 
     func makeSearchResultEmpty(state: State) -> String? {
-        if !currentState.searchResultItems.isEmpty { return nil } else if currentState.isSearching { return "검색 결과가 없어요 :(\n다른 키워드로 검색해주세요" } else { return "검색 결과가 없어요 :(\n다른 옵션을 선택해주세요" }
+        if !currentState.searchResultItems.isEmpty { return nil }
+        else if currentState.isSearching { return "검색 결과가 없어요 :(\n다른 키워드로 검색해주세요" }
+        else { return "검색 결과가 없어요 :(\n다른 옵션을 선택해주세요" }
     }
 
     /// 받침에 따라 이/가 를 판단해서 붙여준다.

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
@@ -48,9 +48,8 @@ public final class PopupSearchReactor: Reactor {
         case updateClearButtonIsHidden(to: Bool)
         case updateCurrentPage(to: Int32)
         case updateSearchingState(to: Bool)
-        case updateSearchResultEmpty
         case updateSearchResultBookmark(indexPath: IndexPath)
-        case updateSearchResultDataSource
+        case updateSearchResultSection
 
         case present(target: PresentTarget)
     }
@@ -68,13 +67,12 @@ public final class PopupSearchReactor: Reactor {
         var categoryItems: [TagModel] = []
         var searchResultItems: [SearchResultModel] = []
         var searchResultHeader: SearchResultHeaderModel = SearchResultHeaderModel(filterText: Filter.shared.title)
-        var searchResultEmpty: String?
 
         @Pulse var searchBarText: String? = nil
         @Pulse var present: PresentTarget?
         @Pulse var clearButtonIsHidden: Bool?
         @Pulse var endEditing: Void?
-        @Pulse var updateSearchResultDataSource: Void?
+        @Pulse var updateSearchResultSection: String?
         @Pulse var dismiss: Void?
 
         fileprivate var isSearching: Bool = false
@@ -197,14 +195,11 @@ public final class PopupSearchReactor: Reactor {
         case .updateSearchingState(let isSearching):
             newState.isSearching = isSearching
 
-        case .updateSearchResultEmpty:
-            newState.searchResultEmpty = makeSearchResultEmpty(state: newState)
-
         case .updateSearchResultBookmark(let indexPath):
             newState.searchResultItems[indexPath.item].isBookmark.toggle()
 
-        case .updateSearchResultDataSource:
-            newState.updateSearchResultDataSource = ()
+        case .updateSearchResultSection:
+            newState.updateSearchResultSection = makeSearchResultEmpty(state: newState)
 
         case .present(let target):
             newState.present = target
@@ -397,7 +392,7 @@ private extension PopupSearchReactor {
         removeRecentSearchItem(text: text)
         return Observable.concat([
             .just(.setupRecentSearch(items: makeRecentSearchItems())),
-            .just(.updateSearchResultDataSource)
+            .just(.updateSearchResultSection)
         ])
     }
 
@@ -405,7 +400,7 @@ private extension PopupSearchReactor {
         removeAllRecentSearchItems()
         return Observable.concat([
             .just(.setupRecentSearch(items: makeRecentSearchItems())),
-            .just(.updateSearchResultDataSource)
+            .just(.updateSearchResultSection)
         ])
     }
 
@@ -431,7 +426,7 @@ private extension PopupSearchReactor {
         return fetchSearchResultBookmark(at: indexPath)
             .andThen(.concat([
                 .just(.updateSearchResultBookmark(indexPath: indexPath)),
-                .just(.updateSearchResultDataSource)
+                .just(.updateSearchResultSection)
             ]))
     }
 
@@ -443,7 +438,7 @@ private extension PopupSearchReactor {
                 Observable.concat([
                     .just(.appendSearchResult(items: owner.makeSearchResultItems(response.popUpStoreList, response.loginYn))),
                     .just(.updateCurrentPage(to: owner.currentState.currentPage + 1)),
-                    .just(.updateSearchResultDataSource)
+                    .just(.updateSearchResultSection)
                 ])
             }
     }
@@ -463,10 +458,9 @@ private extension PopupSearchReactor {
                     .just(.setupSearchResultTotalPageCount(count: response.totalPages)),
                     .just(.updateCurrentPage(to: 0)),
                     .just(.updateSearchingState(to: false)),
-                    .just(.updateSearchResultEmpty),
                     .just(.updateSearchBar(to: nil)),
                     .just(.updateEditingState),
-                    .just(.updateSearchResultDataSource)
+                    .just(.updateSearchResultSection)
                 ])
             }
     }
@@ -487,10 +481,9 @@ private extension PopupSearchReactor {
                     .just(.setupSearchResultTotalPageCount(count: 0)),
                     .just(.updateCurrentPage(to: 0)),
                     .just(.updateSearchingState(to: true)),
-                    .just(.updateSearchResultEmpty),
                     .just(.updateClearButtonIsHidden(to: true)),
                     .just(.updateEditingState),
-                    .just(.updateSearchResultDataSource)
+                    .just(.updateSearchResultSection)
                 ])
             }
     }

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
@@ -354,7 +354,7 @@ private extension PopupSearchReactor {
     }
 
     func handleSearchBarEditing(_ text: String) -> Observable<Mutation> {
-        return .just(.updateClearButtonIsHidden(to: !text.isEmpty))
+        return .just(.updateClearButtonIsHidden(to: text.isEmpty))
     }
 
     func handleSearchBarExitEditing(_ text: String) -> Observable<Mutation> {

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
@@ -48,7 +48,7 @@ public final class PopupSearchReactor: Reactor {
         case updateClearButtonIsHidden(to: Bool)
         case updateCurrentPage(to: Int32)
         case updateSearchingState(to: Bool)
-        case updateSearchResultEmptyTitle
+        case updateSearchResultEmpty
         case updateSearchResultBookmark(indexPath: IndexPath)
         case updateSearchResultDataSource
 
@@ -68,7 +68,7 @@ public final class PopupSearchReactor: Reactor {
         var categoryItems: [TagModel] = []
         var searchResultItems: [SearchResultModel] = []
         var searchResultHeader: SearchResultHeaderModel = SearchResultHeaderModel(filterText: Filter.shared.title)
-        var searchResultEmptyTitle: String?
+        var searchResultEmpty: String?
 
         @Pulse var searchBarText: String? = nil
         @Pulse var present: PresentTarget?
@@ -119,7 +119,7 @@ public final class PopupSearchReactor: Reactor {
                         .just(.setupSearchResult(items: owner.makeSearchResultItems(response.popUpStoreList, response.loginYn))),
                         .just(.setupSearchResultTotalPageCount(count: response.totalPages)),
                         .just(.updateCurrentPage(to: 0)),
-                        .just(.updateSearchResultEmptyTitle),
+                        .just(.updateSearchResultEmpty),
                         .just(.updateSearchResultDataSource)
                     ])
                 }
@@ -142,7 +142,7 @@ public final class PopupSearchReactor: Reactor {
                         .just(.setupSearchResultTotalPageCount(count: 0)),  // FIXME: API에 해당 결과값이 아직 없음
                         .just(.updateCurrentPage(to: 0)),
                         .just(.updateSearchingState(to: true)),
-                        .just(.updateSearchResultEmptyTitle),
+                        .just(.updateSearchResultEmpty),
                         .just(.updateClearButtonIsHidden(to: true)),
                         .just(.updateEditingState),
                         .just(.updateSearchResultDataSource)
@@ -174,7 +174,7 @@ public final class PopupSearchReactor: Reactor {
                             .just(.setupSearchResultTotalPageCount(count: response.totalPages)),
                             .just(.updateCurrentPage(to: 0)),
                             .just(.updateSearchingState(to: false)),
-                            .just(.updateSearchResultEmptyTitle),
+                            .just(.updateSearchResultEmpty),
                             .just(.updateSearchBar(to: nil)),
                             .just(.updateEditingState),
                             .just(.updateSearchResultDataSource)
@@ -199,7 +199,7 @@ public final class PopupSearchReactor: Reactor {
                         .just(.updateCurrentPage(to: 0)),
                         .just(.updateSearchBar(to: keyword)),
                         .just(.updateSearchingState(to: true)),
-                        .just(.updateSearchResultEmptyTitle),
+                        .just(.updateSearchResultEmpty),
                         .just(.updateClearButtonIsHidden(to: true)),
                         .just(.updateEditingState),
                         .just(.updateSearchResultDataSource)
@@ -231,7 +231,7 @@ public final class PopupSearchReactor: Reactor {
                         .just(.setupSearchResultHeader(item: owner.makeSearchResultHeaderInput(count: response.totalElements))),
                         .just(.setupSearchResultTotalPageCount(count: response.totalPages)),
                         .just(.updateCurrentPage(to: 0)),
-                        .just(.updateSearchResultEmptyTitle),
+                        .just(.updateSearchResultEmpty),
                         .just(.updateSearchResultDataSource)
                     ])
                 }
@@ -250,7 +250,7 @@ public final class PopupSearchReactor: Reactor {
                         .just(.setupSearchResultHeader(item: owner.makeSearchResultHeaderInput(count: response.totalElements))),
                         .just(.setupSearchResultTotalPageCount(count: response.totalPages)),
                         .just(.updateCurrentPage(to: 0)),
-                        .just(.updateSearchResultEmptyTitle),
+                        .just(.updateSearchResultEmpty),
                         .just(.updateSearchResultDataSource)
                     ])
             }
@@ -269,7 +269,7 @@ public final class PopupSearchReactor: Reactor {
                         .just(.setupSearchResultHeader(item: owner.makeSearchResultHeaderInput(count: response.totalElements))),
                         .just(.setupSearchResultTotalPageCount(count: response.totalPages)),
                         .just(.updateCurrentPage(to: 0)),
-                        .just(.updateSearchResultEmptyTitle),
+                        .just(.updateSearchResultEmpty),
                         .just(.updateSearchResultDataSource)
                     ])
             }
@@ -335,8 +335,8 @@ public final class PopupSearchReactor: Reactor {
         case .updateSearchingState(let isSearching):
             newState.isSearching = isSearching
 
-        case .updateSearchResultEmptyTitle:
-            newState.searchResultEmptyTitle = makeSearchResultEmptyTitle(state: newState)
+        case .updateSearchResultEmpty:
+            newState.searchResultEmpty = makeSearchResultEmpty(state: newState)
 
         case .updateSearchResultBookmark(let indexPath):
             newState.searchResultItems[indexPath.item].isBookmark.toggle()
@@ -437,7 +437,7 @@ private extension PopupSearchReactor {
         )
     }
 
-    func makeSearchResultEmptyTitle(state: State) -> String? {
+    func makeSearchResultEmpty(state: State) -> String? {
         if !currentState.searchResultItems.isEmpty { return nil } else if currentState.isSearching { return "검색 결과가 없어요 :(\n다른 키워드로 검색해주세요" } else { return "검색 결과가 없어요 :(\n다른 옵션을 선택해주세요" }
     }
 

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/Reactor/PopupSearchReactor.swift
@@ -295,9 +295,7 @@ private extension PopupSearchReactor {
     }
 
     func makeSearchResultEmpty(state: State) -> String? {
-        if !currentState.searchResultItems.isEmpty { return nil }
-        else if currentState.isSearching { return "검색 결과가 없어요 :(\n다른 키워드로 검색해주세요" }
-        else { return "검색 결과가 없어요 :(\n다른 옵션을 선택해주세요" }
+        if !currentState.searchResultItems.isEmpty { return nil } else if currentState.isSearching { return "검색 결과가 없어요 :(\n다른 키워드로 검색해주세요" } else { return "검색 결과가 없어요 :(\n다른 옵션을 선택해주세요" }
     }
 
     /// 받침에 따라 이/가 를 판단해서 붙여준다.
@@ -345,7 +343,6 @@ private extension PopupSearchReactor {
         return isScrollToEnd && hasNextPage
     }
 }
-
 
 // MARK: - Mutate Handlers
 private extension PopupSearchReactor {

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/SectionType/Section.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/SectionType/Section.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum PopupSearchSection: CaseIterable, Hashable {
+    case recentSearch
+    case category
+    case searchResultHeader
+    case searchResult
+}

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/SectionType/Section.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/SectionType/Section.swift
@@ -5,4 +5,5 @@ enum PopupSearchSection: CaseIterable, Hashable {
     case category
     case searchResultHeader
     case searchResult
+    case searchResultEmpty
 }

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/Component/Cell/SearchResultEmptyCollectionViewCell.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/Component/Cell/SearchResultEmptyCollectionViewCell.swift
@@ -6,7 +6,7 @@ import Infrastructure
 import SnapKit
 import Then
 
-final class SearchResultEmptyTitleCollectionViewCell: UICollectionViewCell {
+final class SearchResultEmptyCollectionViewCell: UICollectionViewCell {
 
     // MARK: - Properties
     private let emptyLabel = PPLabel(
@@ -34,7 +34,7 @@ final class SearchResultEmptyTitleCollectionViewCell: UICollectionViewCell {
 }
 
 // MARK: - SetUp
-private extension SearchResultEmptyTitleCollectionViewCell {
+private extension SearchResultEmptyCollectionViewCell {
     func addViews() {
         [emptyLabel].forEach {
             self.addSubview($0)
@@ -52,7 +52,7 @@ private extension SearchResultEmptyTitleCollectionViewCell {
     func configureUI() { }
 }
 
-extension SearchResultEmptyTitleCollectionViewCell {
+extension SearchResultEmptyCollectionViewCell {
     func configureCell(title: String) {
         self.emptyLabel.text = title
     }

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
@@ -31,7 +31,7 @@ final class PopupSearchView: UIView {
             guard let self, let dataSource else { return nil }
             return dataSource.sectionIdentifier(for: index)
         }
-        
+
         $0.setCollectionViewLayout(layoutFactory.makeCollectionViewLayout(), animated: false)
 
         $0.register(

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
@@ -59,8 +59,8 @@ final class PopupSearchView: UIView {
         )
 
         $0.register(
-            SearchResultEmptyTitleCollectionViewCell.self,
-            forCellWithReuseIdentifier: SearchResultEmptyTitleCollectionViewCell.identifiers
+            SearchResultEmptyCollectionViewCell.self,
+            forCellWithReuseIdentifier: SearchResultEmptyCollectionViewCell.identifiers
         )
 
         // UICollectionView 최 상/하단 빈 영역
@@ -206,11 +206,11 @@ extension PopupSearchView {
 
                 return cell
 
-            case .searchResultEmptyTitle(let title):
+            case .searchResultEmptyItem(let title):
                 let cell = collectionView.dequeueReusableCell(
-                    withReuseIdentifier: SearchResultEmptyTitleCollectionViewCell.identifiers,
+                    withReuseIdentifier: SearchResultEmptyCollectionViewCell.identifiers,
                     for: indexPath
-                ) as! SearchResultEmptyTitleCollectionViewCell
+                ) as! SearchResultEmptyCollectionViewCell
 
                 cell.configureCell(title: title)
 
@@ -314,7 +314,7 @@ extension PopupSearchView {
         case categoryItem(TagModel)
         case searchResultHeaderItem(SearchResultHeaderModel)
         case searchResultItem(SearchResultModel)
-        case searchResultEmptyTitle(String)
+        case searchResultEmptyItem(String)
     }
 
     /// Section의 헤더를 구분하기 위한 변수

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
@@ -11,7 +11,7 @@ import Then
 final class PopupSearchView: UIView {
 
     // MARK: - Properties
-    private var dataSource: UICollectionViewDiffableDataSource<Section, SectionItem>?
+    private var dataSource: UICollectionViewDiffableDataSource<PopupSearchSection, SectionItem>?
     private let layoutFactory: PopupSearchLayoutFactory = PopupSearchLayoutFactory()
 
     let recentSearchTagRemoveButtonTapped = PublishRelay<String>()
@@ -118,7 +118,7 @@ private extension PopupSearchView {
 extension PopupSearchView {
     private func configurationDataSourceItem() {
         self.dataSource = UICollectionViewDiffableDataSource<
-            PopupSearchView.Section,
+            PopupSearchSection,
             PopupSearchView.SectionItem
         >(
             collectionView: collectionView
@@ -252,7 +252,7 @@ extension PopupSearchView {
         }
     }
 
-    func updateSectionSnapshot(at section: Section, with items: [SectionItem]) {
+    func updateSectionSnapshot(at section: PopupSearchSection, with items: [SectionItem]) {
         if items.isEmpty {
             guard var snapshot = dataSource?.snapshot() else { return }
             snapshot.deleteSections([section])
@@ -293,21 +293,13 @@ extension PopupSearchView {
         dataSource?.apply(snapshot, animatingDifferences: false)
     }
 
-    func getSectionsFromDataSource() -> [Section] {
+    func getSectionsFromDataSource() -> [PopupSearchSection] {
         return dataSource?.snapshot().sectionIdentifiers ?? []
     }
 }
 
 // MARK: - Section information
 extension PopupSearchView {
-    /// View를 구성하는 section을 정의
-    enum Section: CaseIterable, Hashable {
-        case recentSearch
-        case category
-        case searchResultHeader
-        case searchResult
-    }
-
     /// Section에 들어갈 Item을 정의한 변수
     enum SectionItem: Hashable {
         case recentSearchItem(TagModel)

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
@@ -27,9 +27,12 @@ final class PopupSearchView: UIView {
     public let searchBar = PPSearchBarView()
 
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then {
-        let layout = layoutFactory.makeCollectionViewLayout { [weak self] in self?.dataSource }
-
-        $0.setCollectionViewLayout(layout, animated: false)
+        layoutFactory.setSectionProvider { [weak self] index in
+            guard let self, let dataSource else { return nil }
+            return dataSource.sectionIdentifier(for: index)
+        }
+        
+        $0.setCollectionViewLayout(layoutFactory.makeCollectionViewLayout(), animated: false)
 
         $0.register(
             TagCollectionHeaderView.self,

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
@@ -278,16 +278,18 @@ extension PopupSearchView {
         empty: SectionItem? = nil
     ) {
         guard var snapshot = dataSource?.snapshot() else { return }
-
-        snapshot.deleteSections([.searchResultHeader, .searchResult])
-
-        snapshot.appendSections( [.searchResultHeader, .searchResult])
-        snapshot.appendItems([header], toSection: .searchResultHeader)
+        snapshot.deleteSections([.searchResultHeader, .searchResult, .searchResultEmpty])
 
         if let empty {
-            snapshot.appendItems([empty], toSection: .searchResult)
+            snapshot.appendSections([.searchResultHeader, .searchResultEmpty])
+            snapshot.appendItems([header], toSection: .searchResultHeader)
+            snapshot.appendItems([empty], toSection: .searchResultEmpty)
+            collectionView.isScrollEnabled = false
         } else {
+            snapshot.appendSections([.searchResultHeader, .searchResult])
+            snapshot.appendItems([header], toSection: .searchResultHeader)
             snapshot.appendItems(items, toSection: .searchResult)
+            collectionView.isScrollEnabled = true
         }
 
         dataSource?.apply(snapshot, animatingDifferences: false)

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchView.swift
@@ -12,7 +12,7 @@ final class PopupSearchView: UIView {
 
     // MARK: - Properties
     private var dataSource: UICollectionViewDiffableDataSource<PopupSearchSection, SectionItem>?
-    private let layoutFactory: PopupSearchLayoutFactory = PopupSearchLayoutFactory()
+    private var layoutFactory: PopupSearchLayoutFactory = PopupSearchLayoutFactory()
 
     let recentSearchTagRemoveButtonTapped = PublishRelay<String>()
     let recentSearchTagRemoveAllButtonTapped = PublishRelay<Void>()

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchViewController.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchViewController.swift
@@ -205,11 +205,11 @@ extension PopupSearchViewController {
             .withLatestFrom(reactor.state)
             .withUnretained(self)
             .subscribe { (owner, state) in
-                if let emptyTitle = state.searchResultEmptyTitle {
+                if let searchResultEmpty = state.searchResultEmpty {
                     owner.mainView.updateSearchResultSectionSnapshot(
                         with: state.searchResultItems.map(PopupSearchView.SectionItem.searchResultItem),
                         header: PopupSearchView.SectionItem.searchResultHeaderItem(state.searchResultHeader),
-                        empty: PopupSearchView.SectionItem.searchResultEmptyTitle(emptyTitle)
+                        empty: PopupSearchView.SectionItem.searchResultEmptyItem(searchResultEmpty)
                     )
                 } else {
                     owner.mainView.updateSearchResultSectionSnapshot(

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchViewController.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchViewController.swift
@@ -207,15 +207,17 @@ extension PopupSearchViewController {
             }
             .disposed(by: disposeBag)
 
-        reactor.pulse(\.$updateSearchResultDataSource)
+        reactor.pulse(\.$updateSearchResultSection)
             .withLatestFrom(reactor.state)
             .withUnretained(self)
             .subscribe { (owner, state) in
+                let isEmpty = state.updateSearchResultSection == nil
+                let emptyCaseTitle = state.updateSearchResultSection
+
                 owner.mainView.updateSearchResultSectionSnapshot(
                     with: state.searchResultItems.map(PopupSearchView.SectionItem.searchResultItem),
                     header: PopupSearchView.SectionItem.searchResultHeaderItem(state.searchResultHeader),
-                    empty: state.searchResultEmpty == nil ? nil :
-                    PopupSearchView.SectionItem.searchResultEmptyItem(state.searchResultEmpty!)
+                    empty: isEmpty ? nil : PopupSearchView.SectionItem.searchResultEmptyItem(emptyCaseTitle!)
                 )
             }
             .disposed(by: disposeBag)

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchViewController.swift
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature/PopupSearch/View/PopupSearchViewController.swift
@@ -93,12 +93,18 @@ extension PopupSearchViewController {
                 switch sections[indexPath.section] {
                 case .recentSearch:
                     return Reactor.Action.recentSearchTagButtonTapped(indexPath: indexPath)
+
                 case .category:
                     return Reactor.Action.categoryTagButtonTapped
 
-                case .searchResultHeader: return nil
+                case .searchResultHeader:
+                    return nil
+
                 case .searchResult:
                     return Reactor.Action.searchResultItemTapped(indexPath: indexPath)
+
+                case .searchResultEmpty:
+                    return nil
                 }
             }
             .bind(to: reactor.action)
@@ -205,18 +211,12 @@ extension PopupSearchViewController {
             .withLatestFrom(reactor.state)
             .withUnretained(self)
             .subscribe { (owner, state) in
-                if let searchResultEmpty = state.searchResultEmpty {
-                    owner.mainView.updateSearchResultSectionSnapshot(
-                        with: state.searchResultItems.map(PopupSearchView.SectionItem.searchResultItem),
-                        header: PopupSearchView.SectionItem.searchResultHeaderItem(state.searchResultHeader),
-                        empty: PopupSearchView.SectionItem.searchResultEmptyItem(searchResultEmpty)
-                    )
-                } else {
-                    owner.mainView.updateSearchResultSectionSnapshot(
-                        with: state.searchResultItems.map(PopupSearchView.SectionItem.searchResultItem),
-                        header: PopupSearchView.SectionItem.searchResultHeaderItem(state.searchResultHeader)
-                    )
-                }
+                owner.mainView.updateSearchResultSectionSnapshot(
+                    with: state.searchResultItems.map(PopupSearchView.SectionItem.searchResultItem),
+                    header: PopupSearchView.SectionItem.searchResultHeaderItem(state.searchResultHeader),
+                    empty: state.searchResultEmpty == nil ? nil :
+                    PopupSearchView.SectionItem.searchResultEmptyItem(state.searchResultEmpty!)
+                )
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 이슈

- #150 

## ✅ 작업 사항

- [x] 팩토리 세분화
- [x] 재사용 가능한 팩토리로 수정
- [x] 레이아웃 빌더를 도입

## 🚀 테스트 방식

SearchFeature 데모를 실행하여 검색 화면이 이전과 동일한 레이아웃을 제공해주는지 테스트 

## 👀 ETC (추후 개발해야 할 것, 참고자료 등)

새롭게 도입한 빌더 패턴은 기존의 Sectionable이 제공해주었던 CollectionLayout이 만들기 쉽지 않다는 문제점을 개선하기 위해 도입했던 부분에 충분히 공감하였기에 새롭게 제시하는 방식입니다.

현재 검색화면을 만드는데에는 충분히 커버를 해주고있지만, 팀원분들의 화면을 커버 가능한지 확인이 필요합니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 복잡한 컬렉션 뷰 레이아웃 구성을 위한 빌더 도입.
  - 표준화된 섹션 및 헤더 레이아웃을 위한 프로토콜과 레이아웃 제공자 추가.
  - 빈 검색 결과를 표시하는 전용 셀과 새로운 섹션 타입 추가.

- **Refactor**
  - 검색 기능 내 섹션 처리를 단일 열거형으로 통합.
  - 레이아웃 생성과 변이 처리 로직을 모듈화 및 간소화.
  - 빈 검색 결과 셀 명명 일관성 개선.

- **Bug Fixes**
  - 빈 검색 결과 섹션의 아이템 선택 시 의도치 않은 동작 방지.

- **Chores**
  - 의존성 및 파일 관리를 위한 프로젝트 구성과 `.gitignore` 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->