### PR TITLE
[FEAT] fastlane을 이용한 사이닝과 테스트 빌드 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ fastlane/test_output
 # Cursor
 **/buildServer.json
 .vscode/*
+*.env

--- a/Poppool/Gemfile
+++ b/Poppool/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/Poppool/Poppool.xcodeproj/project.pbxproj
+++ b/Poppool/Poppool.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 250715.1858;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9JZYRP3D46;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -446,7 +446,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.poppoolIOS.poppool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -473,7 +473,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 250715.1858;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9JZYRP3D46;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -493,7 +493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.poppoolIOS.poppool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Poppool/Poppool.xcodeproj/project.pbxproj
+++ b/Poppool/Poppool.xcodeproj/project.pbxproj
@@ -424,11 +424,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Poppool/Resource/Poppool.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5QTRMS954;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9JZYRP3D46;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Poppool/Resource/Info.plist;
@@ -450,7 +450,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.poppoolIOS.poppool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PoppoolGitHubAction;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.poppoolIOS.poppool";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -475,7 +475,7 @@
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5QTRMS954;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9JZYRP3D46;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Poppool/Resource/Info.plist;
@@ -497,7 +497,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.poppoolIOS.poppool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = PoppoolGitHubAction;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.poppoolIOS.poppool";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Poppool/Poppool/Resource/Info.plist
+++ b/Poppool/Poppool/Resource/Info.plist
@@ -18,7 +18,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>250715.1858</string>
 	<key>KAKAO_AUTH_APP_KEY</key>
 	<string>${KAKAO_AUTH_APP_KEY}</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Poppool/PresentationLayer/SearchFeature/SearchFeature.xcodeproj/project.pbxproj
+++ b/Poppool/PresentationLayer/SearchFeature/SearchFeature.xcodeproj/project.pbxproj
@@ -678,7 +678,7 @@
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = W5QTRMS954;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9JZYRP3D46;
 				GENERATE_INFOPLIST_FILE = YES;
 				IBSC_COMPILER_AUTO_ACTIVATE_CUSTOM_FONTS = YES;
 				INFOPLIST_FILE = SearchFeatureDemo/Resource/Info.plist;
@@ -695,7 +695,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.poppoolIOS.poppool.SearchFeatureDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = poppoolSearchFeatureDemoProvisioning;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.poppoolIOS.*";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -714,8 +714,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT = NO;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9JZYRP3D46;
 				GENERATE_INFOPLIST_FILE = YES;
 				IBSC_COMPILER_AUTO_ACTIVATE_CUSTOM_FONTS = YES;
 				INFOPLIST_FILE = SearchFeatureDemo/Resource/Info.plist;
@@ -731,6 +734,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.poppoolIOS.poppool.SearchFeatureDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.poppoolIOS.*";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/Poppool/fastlane/Appfile
+++ b/Poppool/fastlane/Appfile
@@ -1,0 +1,8 @@
+app_identifier("com.poppoolIOS.poppool") # The bundle identifier of your app
+apple_id("thddudgns972@gmail.com") # Your Apple Developer Portal username
+
+itc_team_id("127871563") # App Store Connect Team ID
+team_id("9JZYRP3D46") # Developer Portal Team ID
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile

--- a/Poppool/fastlane/Fastfile
+++ b/Poppool/fastlane/Fastfile
@@ -1,0 +1,30 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:ios)
+
+platform :ios do
+  desc "Push a new beta build to TestFlight"
+  lane :beta do
+    match(type: "appstore")
+    timestamp = Time.now.strftime("%y%m%d.%H%M")
+    increment_build_number(
+      build_number: timestamp,
+      xcodeproj: "Poppool.xcodeproj"
+    )
+    build_app(workspace: "Poppool.xcworkspace", scheme: "Poppool")
+    upload_to_testflight
+  end
+end

--- a/Poppool/fastlane/Matchfile
+++ b/Poppool/fastlane/Matchfile
@@ -1,0 +1,8 @@
+git_url("git@github.com:PopPool/iOS-Signing.git")
+
+storage_mode("git")
+
+type("development") # The default type, can be: appstore, adhoc, enterprise or development
+
+app_identifier(["com.poppoolIOS.poppool"])
+username("thddudgns972@gmail.com")

--- a/Poppool/fastlane/Matchfile
+++ b/Poppool/fastlane/Matchfile
@@ -4,5 +4,5 @@ storage_mode("git")
 
 type("development") # The default type, can be: appstore, adhoc, enterprise or development
 
-app_identifier(["com.poppoolIOS.poppool"])
+app_identifier(["com.poppoolIOS.poppool", "com.poppoolIOS.*"])
 username("thddudgns972@gmail.com")

--- a/Poppool/fastlane/Matchfile
+++ b/Poppool/fastlane/Matchfile
@@ -4,5 +4,5 @@ storage_mode("git")
 
 type("development") # The default type, can be: appstore, adhoc, enterprise or development
 
-app_identifier(["com.poppoolIOS.poppool", "com.poppoolIOS.*"])
+app_identifier(["com.poppoolIOS.poppool", "com.poppoolIOS.*", "com.poppoolIOS.poppool.LoginFeatureDemo"])
 username("thddudgns972@gmail.com")


### PR DESCRIPTION
## 📌 이슈

- #159 

## ✅ 작업 사항

- [x] fastlane match를 통한 자동 사이닝 추가
- [x] fastlane beta를 통한 자동 테스트플라이트 업로드 추가

## 📝 추가 전달

추후 앱스토어 자동 배포 구성과 GitHub Actions를 이용해서 git flow 전략과 통합할 예정입니다. 우선적으로는 match를 이용한 자동 인증서 관리과 beta만 추가해두었습니다.

2주 뒤 있을 1.1.3 배포때 구성해보겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Fastlane 및 관련 구성 파일(Gemfile, Appfile, Fastfile, Matchfile) 추가로 iOS 앱의 자동화된 배포 및 서명 관리 기능이 도입되었습니다.

* **스타일**
  * .gitignore에 *.env 파일 무시 규칙이 추가되었습니다.

* **버그 수정**
  * 프로젝트 및 SearchFeature 데모의 코드 서명, 개발팀, 프로비저닝 프로필 설정이 최신 값으로 변경되었습니다.
  * 앱 버전 및 빌드 번호가 최신 값으로 업데이트되었습니다.

* **문서**
  * Fastlane 관련 파일에 공식 문서 링크 및 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->