### PR TITLE
[FIX] Timer가 계속 메모리에 남아 동작하는 문제 수정

### DIFF
--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Home/Main/HomeController.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Home/Main/HomeController.swift
@@ -37,6 +37,12 @@ extension HomeController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tabBarController?.tabBar.isHidden = false
+        restartBannerAutoScroll()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        stopBannerAutoScroll()  // 화면을 벗어나면 스크롤 중지
     }
 }
 
@@ -127,6 +133,20 @@ extension HomeController {
                 if state.isReloadView { owner.mainView.contentCollectionView.reloadData() }
             }
             .disposed(by: disposeBag)
+    }
+
+    private func stopBannerAutoScroll() {
+        let indexPath = IndexPath(row: 0, section: 0) // 배너 섹션 인덱스
+        if let cell = mainView.contentCollectionView.cellForItem(at: indexPath) as? ImageBannerSectionCell {
+            cell.stopAutoScroll()
+        }
+    }
+
+    private func restartBannerAutoScroll() {
+        let indexPath = IndexPath(row: 0, section: 0)
+        if let cell = mainView.contentCollectionView.cellForItem(at: indexPath) as? ImageBannerSectionCell {
+            cell.startAutoScroll()
+        }
     }
 }
 

--- a/Poppool/PresentationLayer/Presentation/Presentation/Scene/Home/Main/View/ImageBannerSection/ImageBannerSection/ImageBannerSectionCell.swift
+++ b/Poppool/PresentationLayer/Presentation/Presentation/Scene/Home/Main/View/ImageBannerSection/ImageBannerSection/ImageBannerSectionCell.swift
@@ -11,7 +11,7 @@ final class ImageBannerSectionCell: UICollectionViewCell {
 
     var disposeBag = DisposeBag()
 
-    private var autoScrollTimer: Timer?
+    private weak var autoScrollTimer: Timer?
 
     private lazy var contentCollectionView: UICollectionView = {
         let view = UICollectionView(frame: .zero, collectionViewLayout: compositionalLayout)
@@ -73,8 +73,13 @@ final class ImageBannerSectionCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        stopAutoScroll()
         disposeBag = DisposeBag()
         isFirstResponseAutoScroll = false
+    }
+
+    deinit {
+        stopAutoScroll()
     }
 
     // 자동 스크롤 중지 함수


### PR DESCRIPTION
## 📌 이슈

- #180 

## ✅ 작업 사항

- [X] Timer 객체를 약한 참조로 수정
- [X] Cell의 라이프 사이클에 맞춰 타이머를 정지
- [X] ViewController의 라이프 사이클에 맞춰 타이머 시작 또는 정지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 배너 자동 스크롤이 화면 표시 시에는 시작되고 화면 이동 시에는 중지되도록 개선했습니다.
  * 배너 관련 메모리 누수를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->